### PR TITLE
Style Original action as button in items list

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -63,19 +63,25 @@ body {
 
 .search-form { display: grid; gap: 8px; }
 
+.actions button,
+.action-button {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 button {
   padding: 6px 10px;
   border: 1px solid var(--border);
   background: #fff;
   cursor: pointer;
-}
-
-.action-link {
-  padding: 6px 10px;
-  border: 1px solid var(--border);
-  background: #fff;
-  color: var(--text);
-  text-decoration: none;
 }
 
 button.delete { color: var(--danger); }

--- a/templates/items.html
+++ b/templates/items.html
@@ -47,7 +47,7 @@
         </div>
         <div class="actions">
           <button class="refetch" data-item-id="{{.ID}}">Refetch</button>
-          <a class="action-link" href="{{.URL}}" target="_blank" rel="noopener noreferrer">Show original</a>
+          <a class="action-button" href="{{.URL}}" target="_blank" rel="noopener noreferrer">Original</a>
           <button class="delete" data-item-id="{{.ID}}">Delete</button>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- change the items list action label from `Show original` to `Original`
- render Original as a button-style action aligned with Refetch/Delete
- keep opening the original URL in a new tab

## Testing
- not run (UI-only change)

Closes #11