### PR TITLE
Link header brand to main items page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -24,6 +24,12 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.brand {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
 .container { padding: 20px; }
 
 .split {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <header class="topbar">
-    <div class="brand">altpocket</div>
+    <a class="brand" href="/ui/items">altpocket</a>
     <div class="user">{{.User.Name}}</div>
   </header>
   <main class="container">


### PR DESCRIPTION
## Summary
- make the top-left `altpocket` header label a link
- route the link to `/ui/items` (main list page)
- add brand link styling so it keeps header appearance

## Testing
- `go test ./...`

Closes #18
