### PR TITLE
Add styled sign-in and register pages

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,6 +93,8 @@ func (s *Server) Routes() http.Handler {
 	r.Use(RequestID)
 	r.Use(AccessLog(s.logger))
 
+	r.Get("/", s.handleHome)
+	r.Get("/register", s.handleRegister)
 	r.Get("/healthz", s.handleHealth)
 
 	r.Route("/v1", func(r chi.Router) {
@@ -126,6 +128,32 @@ func (s *Server) Routes() http.Handler {
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
+}
+
+func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.webSession(r); ok {
+		http.Redirect(w, r, "/ui/items", http.StatusFound)
+		return
+	}
+	data := map[string]interface{}{
+		"Title": "Sign In",
+	}
+	if err := s.renderer.Render(w, "home", data); err != nil {
+		http.Error(w, "render error", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.webSession(r); ok {
+		http.Redirect(w, r, "/ui/items", http.StatusFound)
+		return
+	}
+	data := map[string]interface{}{
+		"Title": "Register",
+	}
+	if err := s.renderer.Render(w, "register", data); err != nil {
+		http.Error(w, "render error", http.StatusInternalServerError)
+	}
 }
 
 func (s *Server) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -25,10 +25,20 @@ func New(templateDir string) (*Renderer, error) {
 	}
 
 	layout := filepath.Join(templateDir, "layout.html")
+	home := filepath.Join(templateDir, "home.html")
+	register := filepath.Join(templateDir, "register.html")
 	items := filepath.Join(templateDir, "items.html")
 	detail := filepath.Join(templateDir, "item_detail.html")
 	quickAdd := filepath.Join(templateDir, "quick_add.html")
 
+	homeTpl, err := template.New("layout.html").Funcs(funcMap).ParseFiles(layout, home)
+	if err != nil {
+		return nil, err
+	}
+	registerTpl, err := template.New("layout.html").Funcs(funcMap).ParseFiles(layout, register)
+	if err != nil {
+		return nil, err
+	}
 	itemsTpl, err := template.New("layout.html").Funcs(funcMap).ParseFiles(layout, items)
 	if err != nil {
 		return nil, err
@@ -42,6 +52,8 @@ func New(templateDir string) (*Renderer, error) {
 		return nil, err
 	}
 	return &Renderer{templates: map[string]*template.Template{
+		"home":      homeTpl,
+		"register":  registerTpl,
 		"items":     itemsTpl,
 		"detail":    detailTpl,
 		"quick_add": quickAddTpl,

--- a/static/style.css
+++ b/static/style.css
@@ -580,6 +580,43 @@ button:hover {
   place-items: center;
 }
 
+.auth-shell {
+  min-height: calc(100vh - 240px);
+  display: grid;
+  place-items: center;
+}
+
+.auth-card {
+  width: min(720px, 100%);
+  padding: 28px;
+  display: grid;
+  gap: 12px;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: clamp(30px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.auth-eyebrow {
+  margin: 0;
+  color: var(--color-info);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.auth-actions {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 .quick-add-card {
   width: min(760px, 100%);
   padding: 24px;
@@ -680,13 +717,16 @@ summary:focus-visible {
   }
 
   .quick-add-actions,
-  .item-actions {
+  .item-actions,
+  .auth-actions {
     flex-direction: column;
     align-items: stretch;
   }
 
   .quick-add-actions .btn-secondary,
   .quick-add-actions .btn-primary,
+  .auth-actions .btn-secondary,
+  .auth-actions .btn-primary,
   .item-actions .btn-secondary,
   .item-actions .btn-primary {
     width: 100%;

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,14 @@
+{{define "content"}}
+<section class="auth-shell">
+  <article class="card auth-card">
+    <p class="auth-eyebrow">Read-it-later for engineers</p>
+    <h1>Save pages fast with altpocket</h1>
+    <p class="muted">Sign in with Google to start saving pages, tagging resources, and searching across your private knowledge base.</p>
+
+    <div class="auth-actions">
+      <a class="btn-primary" href="/v1/auth/google/login">Sign in with Google</a>
+      <a class="btn-secondary" href="/register">Create an account</a>
+    </div>
+  </article>
+</section>
+{{end}}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,12 +12,20 @@
 <body>
   <header class="topbar">
     <div class="topbar-inner">
-      <a class="brand" href="/ui/items">altpocket</a>
-      <nav class="topnav" aria-label="Primary">
-        <a href="/ui/items">Items</a>
-        <a href="/ui/quick-add">Quick Add</a>
-      </nav>
-      <div class="user-pill">{{.User.Name}}</div>
+      {{if .User}}
+        <a class="brand" href="/ui/items">altpocket</a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="/ui/items">Items</a>
+          <a href="/ui/quick-add">Quick Add</a>
+        </nav>
+        <div class="user-pill">{{.User.Name}}</div>
+      {{else}}
+        <a class="brand" href="/">altpocket</a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="/v1/auth/google/login">Sign in</a>
+          <a href="/register">Register</a>
+        </nav>
+      {{end}}
     </div>
   </header>
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,14 @@
+{{define "content"}}
+<section class="auth-shell">
+  <article class="card auth-card">
+    <p class="auth-eyebrow">Welcome to altpocket</p>
+    <h1>Create your account</h1>
+    <p class="muted">Register with Google. We will create your account and redirect you to your items page after authentication.</p>
+
+    <div class="auth-actions">
+      <a class="btn-primary" href="/v1/auth/google/login">Register with Google</a>
+      <a class="btn-secondary" href="/">Back to sign in</a>
+    </div>
+  </article>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- add a public sign-in top page at `/` with a Sign in with Google CTA
- add a public register page at `/register` with a Register with Google CTA
- keep OAuth flow on existing endpoint `/v1/auth/google/login`
- redirect already signed-in users from `/` and `/register` to `/ui/items`
- align both pages with current UI modernization styles

## Testing
- go test ./...

Closes #24
