### PR TITLE
Add async extension capture upload and protect captured content

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Web UI: http://localhost:8080/ui/items
 1. `extension/popup.js` の `CLIENT_ID` を自分のExtension用OAuthクライアントIDに置換
 2. Chromeの拡張機能管理画面で「パッケージ化されていない拡張機能を読み込む」→ `extension/` を選択
 3. 拡張機能アイコンをクリックしてSide Panelを開き、API Base URLを入力して Login → Save Current Tab
+4. Save時はまずURL/タグだけを保存し、その後拡張機能が抽出した本文を非同期で `POST /v1/items/:id/capture` に送信します（保存操作は待たない）
 
 ## モバイル登録導線
 
@@ -60,6 +61,7 @@ Web UI: http://localhost:8080/ui/items
 
 ## API概要
 - `POST /v1/items` {url,tags[]} -> 200 {item_id, created}
+- `POST /v1/items/:id/capture` {title,content_full} -> 204（拡張機能の非同期本文アップロード）
 - `GET /v1/items` page/per_page/q/tag/sort
 - `GET /v1/items/:id`
 - `DELETE /v1/items/:id`

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "assets/icon48.png",
     "128": "assets/icon128.png"
   },
-  "permissions": ["identity", "storage", "activeTab", "sidePanel"],
+  "permissions": ["identity", "storage", "activeTab", "sidePanel", "scripting"],
   "optional_host_permissions": ["https://*/*"],
   "background": {
     "service_worker": "background.js"

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -13,6 +13,8 @@ const suggestionsEl = document.getElementById('suggestions');
 let tags = [];
 let token = null;
 
+const CONTENT_CAPTURE_LIMIT = 200_000;
+
 function setAuthControlsVisible(visible) {
   if (!authControlsEl) return;
   authControlsEl.hidden = !visible;
@@ -155,6 +157,102 @@ function apiErrorMessage(status, data, fallback) {
 
 function isAuthFailureStatus(status) {
   return status === 401 || status === 403;
+}
+
+async function extractPageCapture(tabId) {
+  if (!chrome.scripting || typeof chrome.scripting.executeScript !== 'function') {
+    return null;
+  }
+  if (typeof tabId !== 'number') {
+    return null;
+  }
+
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: (limit) => {
+        const normalize = (v) => v.trim().replace(/\s+/g, ' ');
+        const truncate = (v, max) => (v.length > max ? v.slice(0, max) : v);
+        const selectorsToDrop = [
+          'script',
+          'style',
+          'noscript',
+          'template',
+          'svg',
+          'canvas',
+          'iframe',
+          'nav',
+          'aside',
+          'footer',
+          'form',
+          '[hidden]',
+          '[aria-hidden="true"]',
+        ];
+
+        const source = document.querySelector('article, main, [role="main"]') || document.body;
+        if (!source) {
+          return null;
+        }
+
+        const clone = source.cloneNode(true);
+        for (const selector of selectorsToDrop) {
+          clone.querySelectorAll(selector).forEach((node) => node.remove());
+        }
+
+        const rawText = clone.innerText || clone.textContent || '';
+        const contentFull = truncate(normalize(rawText), limit);
+        if (!contentFull) {
+          return null;
+        }
+
+        return {
+          title: normalize(document.title || ''),
+          content_full: contentFull,
+        };
+      },
+      args: [CONTENT_CAPTURE_LIMIT],
+    });
+    if (!Array.isArray(results) || results.length === 0) {
+      return null;
+    }
+    const value = results[0]?.result;
+    if (!value || typeof value.content_full !== 'string' || value.content_full === '') {
+      return null;
+    }
+    return {
+      title: typeof value.title === 'string' ? value.title : '',
+      content_full: value.content_full,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function sendCapturedContent(apiBase, itemID, capture) {
+  if (!capture || !capture.content_full) {
+    return;
+  }
+  if (!token) {
+    return;
+  }
+
+  let res;
+  try {
+    res = await fetch(`${apiBase}/v1/items/${encodeURIComponent(itemID)}/capture`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify(capture),
+    });
+  } catch {
+    return;
+  }
+
+  if (isAuthFailureStatus(res.status)) {
+    await moveToUnauthenticated('Session expired. Please sign in again.', 'error');
+  }
 }
 
 function renderTags() {
@@ -322,7 +420,20 @@ async function saveCurrentTab() {
       setError(apiErrorMessage(res.status, data, 'Save failed'));
       return;
     }
+
+    const { data } = await readResponseBody(res);
+    const itemID = typeof data?.item_id === 'string' ? data.item_id : '';
+    const created = data?.created === true;
     setSuccess('Saved');
+
+    if (!created || itemID === '') {
+      return;
+    }
+
+    void (async () => {
+      const capture = await extractPageCapture(tab.id);
+      await sendCapturedContent(apiBase, itemID, capture);
+    })();
   } catch (err) {
     setError(`Save error: ${errorMessage(err, 'unexpected error')}`);
   }

--- a/extension/popup.test.mjs
+++ b/extension/popup.test.mjs
@@ -104,6 +104,9 @@ function createChromeMock({
   tabURL = 'https://example.com/current',
   permissionsDefaultGranted = true,
   permissionsRequestResult = true,
+  enableScripting = false,
+  scriptingExecuteResult = null,
+  scriptingExecuteError = null,
 } = {}) {
   const data = { ...storageData };
   const storageSetCalls = [];
@@ -111,6 +114,7 @@ function createChromeMock({
   const identityCalls = [];
   const permissionContainsCalls = [];
   const permissionRequestCalls = [];
+  const scriptingExecuteCalls = [];
 
   const chrome = {
     identity: {
@@ -164,10 +168,25 @@ function createChromeMock({
     },
     tabs: {
       async query() {
-        return [{ url: tabURL }];
+        return [{ id: 1, url: tabURL }];
       },
     },
   };
+
+  if (enableScripting) {
+    chrome.scripting = {
+      async executeScript(args) {
+        scriptingExecuteCalls.push(args);
+        if (scriptingExecuteError) {
+          throw scriptingExecuteError;
+        }
+        if (scriptingExecuteResult === null) {
+          return [{ result: null }];
+        }
+        return [{ result: scriptingExecuteResult }];
+      },
+    };
+  }
 
   return {
     chrome,
@@ -176,6 +195,7 @@ function createChromeMock({
     identityCalls,
     permissionContainsCalls,
     permissionRequestCalls,
+    scriptingExecuteCalls,
     storageData: data,
   };
 }
@@ -219,6 +239,7 @@ async function loadPopupScript(options = {}) {
     identityCalls,
     permissionContainsCalls,
     permissionRequestCalls,
+    scriptingExecuteCalls,
     storageData,
   } = createChromeMock(options);
   const { fetch, calls } = createFetchMock(options.fetchHandlers || []);
@@ -248,6 +269,7 @@ async function loadPopupScript(options = {}) {
     identityCalls,
     permissionContainsCalls,
     permissionRequestCalls,
+    scriptingExecuteCalls,
     storageData,
   };
 }
@@ -371,6 +393,40 @@ test('save current tab sends bearer token and tags', async () => {
   assert.equal(env.elements.status.textContent, 'Saved');
   assert.equal(env.elements.status.className, 'status status-success');
   assert.equal(env.elements.authControls.hidden, false);
+});
+
+test('save sends captured content asynchronously when item is newly created', async () => {
+  const env = await loadPopupScript({
+    storageData: {
+      apiBase: 'https://api.example.test',
+      token: 'stored-token',
+    },
+    enableScripting: true,
+    scriptingExecuteResult: {
+      title: 'Captured title',
+      content_full: 'Captured body text',
+    },
+    fetchHandlers: [
+      jsonResponse(200, { item_id: 'item-123', created: true }),
+      jsonResponse(204, {}),
+    ],
+    tabURL: 'https://news.example/item',
+  });
+
+  await env.elements.save.click();
+  await flushTasks();
+
+  assert.equal(env.fetchCalls.length, 2);
+  assert.equal(env.fetchCalls[0].url, 'https://api.example.test/v1/items');
+  assert.equal(env.fetchCalls[1].url, 'https://api.example.test/v1/items/item-123/capture');
+  assert.equal(env.fetchCalls[1].options.method, 'POST');
+  assert.equal(env.fetchCalls[1].options.headers.Authorization, 'Bearer stored-token');
+
+  const capturePayload = JSON.parse(env.fetchCalls[1].options.body);
+  assert.equal(capturePayload.title, 'Captured title');
+  assert.equal(capturePayload.content_full, 'Captured body text');
+  assert.equal(env.scriptingExecuteCalls.length, 1);
+  assert.equal(env.scriptingExecuteCalls[0].target.tabId, 1);
 });
 
 test('login surfaces exchange network errors', async () => {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"altpocket/internal/auth"
 	"altpocket/internal/config"
@@ -41,6 +42,8 @@ type Server struct {
 }
 
 var errInvalidURL = errors.New("invalid_url")
+
+const maxCapturedContentPayloadBytes = 256 * 1024
 
 func New(cfg config.Config, st *store.Store, limiter *ratelimit.Limiter, log *slog.Logger, renderer *ui.Renderer) *Server {
 	oauthCfg := &oauth2.Config{
@@ -111,6 +114,7 @@ func (s *Server) Routes() http.Handler {
 			r.Post("/", s.requireAuth(s.handleCreateItem))
 			r.Get("/{id}", s.requireAuth(s.handleGetItem))
 			r.Put("/{id}/tags", s.requireAuth(s.handleUpdateItemTags))
+			r.Post("/{id}/capture", s.requireAuth(s.handleCaptureItemContent))
 			r.Delete("/{id}", s.requireAuth(s.handleDeleteItem))
 			r.Post("/{id}/refetch", s.requireAuth(s.handleRefetchItem))
 		})
@@ -438,6 +442,55 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "db_error"})
 		return
 	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleCaptureItemContent(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxCapturedContentPayloadBytes)
+	var req struct {
+		Title       string `json:"title"`
+		ContentFull string `json:"content_full"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	contentFull := truncateUTF8(strings.TrimSpace(req.ContentFull), s.cfg.ContentFullLimit)
+	if contentFull == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	searchText := normalizeWhitespace(contentFull)
+	excerpt := truncateUTF8(searchText, 200)
+	contentSearch := truncateUTF8(searchText, s.cfg.ContentSearchLimit)
+	itemID := chi.URLParam(r, "id")
+
+	if err := s.store.UpdateCapturedContent(
+		r.Context(),
+		user.ID,
+		itemID,
+		strings.TrimSpace(req.Title),
+		excerpt,
+		contentFull,
+		contentSearch,
+		len([]byte(contentFull)),
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not_found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "db_error"})
+		return
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -844,6 +897,25 @@ func parseTagInput(v string) []string {
 		return r == ',' || r == ';' || r == '\n' || r == '\r'
 	})
 	return normalizeTagNames(parts)
+}
+
+func normalizeWhitespace(v string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(v)), " ")
+}
+
+func truncateUTF8(v string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	b := []byte(v)
+	if len(b) <= limit {
+		return v
+	}
+	trunc := b[:limit]
+	for len(trunc) > 0 && !utf8.Valid(trunc) {
+		trunc = trunc[:len(trunc)-1]
+	}
+	return string(trunc)
 }
 
 func extractHTTPURLFromText(v string) string {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -47,6 +47,20 @@ func TestParseTagInput(t *testing.T) {
 	}
 }
 
+func TestNormalizeWhitespace(t *testing.T) {
+	got := normalizeWhitespace("  hello \n  world\tgo  ")
+	if got != "hello world go" {
+		t.Fatalf("unexpected normalized text: %q", got)
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	got := truncateUTF8("あいうえお", 7)
+	if got != "あい" {
+		t.Fatalf("expected UTF-8 safe truncation, got %q", got)
+	}
+}
+
 func TestQuickAddNotice(t *testing.T) {
 	if quickAddNotice("created") == "" {
 		t.Fatalf("created state should return notice")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -544,13 +544,17 @@ func (s *Store) UpdateFetchSuccess(ctx context.Context, itemID, title, excerpt, 
 		}
 	}()
 
-	_, err = tx.Exec(ctx, `
+	tag, err := tx.Exec(ctx, `
 		UPDATE items
 		SET title=$1, excerpt=$2, fetch_status='success', fetch_error='', fetched_at=NOW(), refetch_requested=false
 		WHERE id=$3
+		  AND (fetch_status <> 'success' OR refetch_requested=true)
 	`, title, excerpt, itemID)
 	if err != nil {
 		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return tx.Commit(ctx)
 	}
 
 	_, err = tx.Exec(ctx, `
@@ -570,6 +574,50 @@ func (s *Store) UpdateFetchFailure(ctx context.Context, itemID, reason string) e
 		UPDATE items
 		SET fetch_status='failed', fetch_error=$1, refetch_requested=false
 		WHERE id=$2
+		  AND (fetch_status <> 'success' OR refetch_requested=true)
 	`, reason, itemID)
 	return err
+}
+
+func (s *Store) UpdateCapturedContent(ctx context.Context, userID, itemID, title, excerpt, contentFull, contentSearch string, contentBytes int) error {
+	tx, err := s.DB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE items
+		SET title = CASE WHEN $1 <> '' THEN $1 ELSE title END,
+			excerpt = $2,
+			fetch_status = 'success',
+			fetch_error = '',
+			fetched_at = NOW(),
+			refetch_requested = false
+		WHERE id = $3 AND user_id = $4
+	`, title, excerpt, itemID, userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO item_contents (item_id, content_full, content_search, content_bytes)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (item_id) DO UPDATE
+		SET content_full = EXCLUDED.content_full,
+			content_search = EXCLUDED.content_search,
+			content_bytes = EXCLUDED.content_bytes
+	`, itemID, contentFull, contentSearch, contentBytes)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }


### PR DESCRIPTION
## Summary
- add async extension capture upload flow to improve fetch reliability on JS/WAF-protected pages
- keep initial save fast by sending URL/tags first, then upload extracted content in a separate request
- add new API endpoint `POST /v1/items/:id/capture` for extension-provided content
- prevent worker from overwriting already-successful captured content during normal background fetches
- allow overwrite only when user explicitly requests refetch

## Behavior spec
1. Extension save first calls `POST /v1/items` with URL and tags.
2. If the item is newly created (`created=true`), extension asynchronously extracts page text and calls `POST /v1/items/:id/capture`.
3. Save success UI does **not** wait for capture upload completion.
4. Capture upload failure does not roll back the initial save.
5. Background worker updates (`UpdateFetchSuccess` / `UpdateFetchFailure`) are ignored for items already in `fetch_status='success'` unless `refetch_requested=true`.
6. User-triggered refetch can still overwrite existing captured content.

## Additional notes
- capture payload size is bounded server-side via `http.MaxBytesReader`.
- extension now requires `scripting` permission for page text extraction.

## Testing
- `go test ./...`
- `node --test extension/popup.test.mjs`
