### PR TITLE
Harden CORS to fail closed in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ JWT_SECRET=change-me
 GOOGLE_WEB_CLIENT_ID=your-web-client-id
 GOOGLE_CLIENT_SECRET=your-web-client-secret
 GOOGLE_EXT_CLIENT_ID=your-extension-client-id
+CORS_ALLOW_ORIGINS=chrome-extension://your-extension-id,https://your-web-origin
 ```
+
+`APP_ENV=production` では `CORS_ALLOW_ORIGINS` が必須です（未設定だと起動時にpanicします）。
 
 ### Google OAuth 設定
 - Web: OAuth同意画面 + WebクライアントIDを作成し、リダイレクトURIに `http://localhost:8080/v1/auth/google/callback` を登録

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,23 +8,29 @@ import (
 )
 
 type Config struct {
-	Env               string
-	HTTPAddr          string
-	DatabaseURL       string
-	SessionSecret     string
-	JWTSecret         string
-	GoogleWebClientID string
-	GoogleExtClientID string
+	Env                string
+	HTTPAddr           string
+	DatabaseURL        string
+	SessionSecret      string
+	JWTSecret          string
+	GoogleWebClientID  string
+	GoogleExtClientID  string
 	GoogleClientSecret string
-	PublicBaseURL     string
+	PublicBaseURL      string
 	ContentFullLimit   int
 	ContentSearchLimit int
 	CORSAllowOrigins   []string
 }
 
 func Load() Config {
+	env := getEnv("APP_ENV", "development")
+	corsAllowOrigins := getEnvList("CORS_ALLOW_ORIGINS")
+	if env == "production" && len(corsAllowOrigins) == 0 {
+		panic("missing env: CORS_ALLOW_ORIGINS")
+	}
+
 	return Config{
-		Env:                getEnv("APP_ENV", "development"),
+		Env:                env,
 		HTTPAddr:           getEnv("HTTP_ADDR", ":8080"),
 		DatabaseURL:        mustEnv("DATABASE_URL"),
 		SessionSecret:      mustEnv("SESSION_SECRET"),
@@ -35,7 +41,7 @@ func Load() Config {
 		PublicBaseURL:      mustEnv("PUBLIC_BASE_URL"),
 		ContentFullLimit:   getEnvInt("CONTENT_FULL_LIMIT_BYTES", 1_000_000),
 		ContentSearchLimit: getEnvInt("CONTENT_SEARCH_LIMIT_BYTES", 16_384),
-		CORSAllowOrigins:   getEnvList("CORS_ALLOW_ORIGINS"),
+		CORSAllowOrigins:   corsAllowOrigins,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,39 @@
+package config
+
+import "testing"
+
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db?sslmode=disable")
+	t.Setenv("SESSION_SECRET", "session-secret")
+	t.Setenv("JWT_SECRET", "jwt-secret")
+	t.Setenv("GOOGLE_WEB_CLIENT_ID", "web-client-id")
+	t.Setenv("GOOGLE_EXT_CLIENT_ID", "ext-client-id")
+	t.Setenv("GOOGLE_CLIENT_SECRET", "client-secret")
+	t.Setenv("PUBLIC_BASE_URL", "https://api.example.test")
+}
+
+func TestLoadPanicsWithoutCORSAllowOriginsInProduction(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("CORS_ALLOW_ORIGINS", "")
+
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("expected panic when CORS_ALLOW_ORIGINS is missing in production")
+		}
+	}()
+
+	_ = Load()
+}
+
+func TestLoadAllowsEmptyCORSAllowOriginsInDevelopment(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("CORS_ALLOW_ORIGINS", "")
+
+	cfg := Load()
+	if len(cfg.CORSAllowOrigins) != 0 {
+		t.Fatalf("expected empty CORS allow list, got %#v", cfg.CORSAllowOrigins)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -818,21 +818,14 @@ func (s *Server) requestID(ctx context.Context) string {
 
 func (s *Server) cors(next http.Handler) http.Handler {
 	allowed := s.cfg.CORSAllowOrigins
-	allowAll := len(allowed) == 0
 	allowedSet := map[string]struct{}{}
 	for _, o := range allowed {
 		allowedSet[o] = struct{}{}
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origin := r.Header.Get("Origin")
-		if allowAll {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
-		} else if _, ok := allowedSet[origin]; ok {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Vary", "Origin")
-		} else {
-			// Origin not allowed — skip CORS headers
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin == "" {
 			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusForbidden)
 				return
@@ -840,6 +833,15 @@ func (s *Server) cors(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		_, allowedOrigin := allowedSet[origin]
+		if !allowedOrigin && !requestOriginMatchesHost(r, origin) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Add("Vary", "Origin")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-CSRF-Token")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		if r.Method == http.MethodOptions {
@@ -848,6 +850,17 @@ func (s *Server) cors(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func requestOriginMatchesHost(r *http.Request, origin string) bool {
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, r.Host)
 }
 
 func (s *Server) checkCSRF(r *http.Request) error {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -122,3 +122,80 @@ func TestHandleUIQuickAddShareTargetRedirectsWithURLFallback(t *testing.T) {
 		t.Fatalf("expected title to be forwarded, got %q", got)
 	}
 }
+
+func TestCORSRejectsDisallowedOrigin(t *testing.T) {
+	s := newAuthTestServer()
+	s.cfg.CORSAllowOrigins = []string{"chrome-extension://allowed-extension-id"}
+
+	called := false
+	handler := s.cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.example.test/v1/items", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+	if called {
+		t.Fatalf("expected next handler not to be called")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("disallowed origin must not receive allow-origin header")
+	}
+}
+
+func TestCORSAllowsConfiguredOriginPreflight(t *testing.T) {
+	s := newAuthTestServer()
+	allowed := "chrome-extension://allowed-extension-id"
+	s.cfg.CORSAllowOrigins = []string{allowed}
+
+	handler := s.cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "https://api.example.test/v1/items", nil)
+	req.Header.Set("Origin", allowed)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != allowed {
+		t.Fatalf("expected allow-origin %q, got %q", allowed, rr.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestCORSAllowsSameHostOrigin(t *testing.T) {
+	s := newAuthTestServer()
+	s.cfg.CORSAllowOrigins = nil
+
+	called := false
+	handler := s.cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.example.test/v1/items", nil)
+	req.Header.Set("Origin", "https://api.example.test")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if !called {
+		t.Fatalf("expected next handler to be called")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "https://api.example.test" {
+		t.Fatalf("expected same-host origin to be allowed")
+	}
+}


### PR DESCRIPTION
## Summary
- enforce security-first CORS behavior (fail-closed) instead of fail-open fallback
- require `CORS_ALLOW_ORIGINS` in `APP_ENV=production` (panic when missing)
- reject disallowed origins with `403` for both preflight and non-preflight requests
- allow same-host origin requests to keep web UI same-origin flows working
- add config/server tests for production guardrails and CORS decisions
- update README with `CORS_ALLOW_ORIGINS` usage and production requirement

## Behavior
- No more `Access-Control-Allow-Origin: *` fallback when allowlist is empty.
- In production, misconfiguration (`CORS_ALLOW_ORIGINS` missing/empty) fails at startup.

## Testing
- `go test ./...`

Closes #42
