### PR TITLE
Restore quick-add content fallback from query param

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -826,7 +826,7 @@ func (s *Server) handleUIQuickAdd(w http.ResponseWriter, r *http.Request) {
 	if urlValue == "" {
 		urlValue = extractHTTPURLFromText(textValue)
 	}
-	contentPreview := strings.TrimSpace(r.URL.Query().Get("content"))
+	contentPreview := sanitizeQuickAddContent(r.URL.Query().Get("content"))
 	if contentPreview == "" {
 		contentPreview = quickAddContentPreview(urlValue, textValue)
 	}
@@ -880,7 +880,10 @@ func (s *Server) handleUIQuickAddSubmit(w http.ResponseWriter, r *http.Request) 
 	urlValue := strings.TrimSpace(r.PostFormValue("url"))
 	titleValue := strings.TrimSpace(r.PostFormValue("title"))
 	tagsValue := strings.TrimSpace(r.PostFormValue("tags"))
-	contentPreview := truncateRunes(normalizeWhitespace(r.PostFormValue("content_preview")), quickAddContentPreviewRuneLimit)
+	contentPreview := sanitizeQuickAddContent(r.PostFormValue("content"))
+	if contentPreview == "" {
+		contentPreview = sanitizeQuickAddContent(r.PostFormValue("content_preview"))
+	}
 
 	csrfExpected := s.csrfFromContext(r.Context())
 	csrfProvided := r.PostFormValue("csrf_token")
@@ -907,27 +910,7 @@ func (s *Server) handleUIQuickAddSubmit(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if created && contentPreview != "" {
-		contentFull := truncateUTF8(contentPreview, s.cfg.ContentFullLimit)
-		searchText := normalizeWhitespace(contentFull)
-		excerpt := truncateUTF8(searchText, 200)
-		contentSearch := truncateUTF8(searchText, s.cfg.ContentSearchLimit)
-		if err := s.store.SeedCapturedContent(
-			r.Context(),
-			user.ID,
-			itemID,
-			titleValue,
-			excerpt,
-			contentFull,
-			contentSearch,
-			len([]byte(contentFull)),
-		); err != nil {
-			s.logger.Warn("ui.quick_add.capture_failed",
-				slog.String("request_id", s.requestID(r.Context())),
-				slog.String("item_id", itemID),
-				slog.String("error", err.Error()))
-		}
-	}
+	s.seedQuickAddContent(r.Context(), user.ID, itemID, titleValue, contentPreview)
 
 	if created {
 		http.Redirect(w, r, "/ui/items?quick_add=created", http.StatusFound)
@@ -958,6 +941,33 @@ func (s *Server) renderUIQuickAdd(w http.ResponseWriter, r *http.Request, status
 	}
 	if err := s.renderer.Render(w, "quick_add", data); err != nil {
 		http.Error(w, "render error", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) seedQuickAddContent(ctx context.Context, userID, itemID, titleValue, contentPreview string) {
+	if s.store == nil || contentPreview == "" {
+		return
+	}
+
+	contentFull := truncateUTF8(contentPreview, s.cfg.ContentFullLimit)
+	searchText := normalizeWhitespace(contentFull)
+	excerpt := truncateUTF8(searchText, 200)
+	contentSearch := truncateUTF8(searchText, s.cfg.ContentSearchLimit)
+
+	if err := s.store.SeedCapturedContent(
+		ctx,
+		userID,
+		itemID,
+		titleValue,
+		excerpt,
+		contentFull,
+		contentSearch,
+		len([]byte(contentFull)),
+	); err != nil {
+		s.logger.Warn("ui.quick_add.capture_failed",
+			slog.String("request_id", s.requestID(ctx)),
+			slog.String("item_id", itemID),
+			slog.String("error", err.Error()))
 	}
 }
 
@@ -1317,8 +1327,11 @@ func quickAddContentPreview(urlValue, textValue string) string {
 	if urlValue != "" {
 		candidate = strings.ReplaceAll(candidate, urlValue, " ")
 	}
-	candidate = truncateRunes(normalizeWhitespace(candidate), quickAddContentPreviewRuneLimit)
-	return candidate
+	return sanitizeQuickAddContent(candidate)
+}
+
+func sanitizeQuickAddContent(v string) string {
+	return truncateRunes(normalizeWhitespace(v), quickAddContentPreviewRuneLimit)
 }
 
 func truncateRunes(v string, limit int) string {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -134,6 +134,21 @@ func TestQuickAddContentPreviewTruncatesTo200Runes(t *testing.T) {
 	}
 }
 
+func TestSanitizeQuickAddContentNormalizesWhitespace(t *testing.T) {
+	got := sanitizeQuickAddContent("  one \n two\tthree  ")
+	if got != "one two three" {
+		t.Fatalf("unexpected sanitized content: %q", got)
+	}
+}
+
+func TestSanitizeQuickAddContentTruncatesTo200Runes(t *testing.T) {
+	input := strings.Repeat("a", 220)
+	got := sanitizeQuickAddContent(input)
+	if len([]rune(got)) != 200 {
+		t.Fatalf("expected 200 runes, got %d", len([]rune(got)))
+	}
+}
+
 func TestHandleUIQuickAddShareTargetRedirectsWithURLFallback(t *testing.T) {
 	s := newAuthTestServer()
 	form := "title=Example+Article&text=Read+https%3A%2F%2Fexample.com%2Fabc+later"

--- a/templates/quick_add.html
+++ b/templates/quick_add.html
@@ -24,7 +24,7 @@
       {{if .ContentPreview}}
       <label class="field" for="quick-add-content-preview">
         <span class="field-label">Captured text (read-only, up to 200 chars)</span>
-        <textarea id="quick-add-content-preview" class="input" name="content_preview" rows="5" readonly>{{.ContentPreview}}</textarea>
+        <textarea id="quick-add-content-preview" class="input" name="content" rows="5" readonly>{{.ContentPreview}}</textarea>
       </label>
       {{end}}
 


### PR DESCRIPTION
## What
- restore `/ui/quick-add?content=...` handling and sanitize it (whitespace normalize + 200-char limit)
- keep captured content in the form as read-only `name="content"` and send it on submit
- accept both `content` and legacy `content_preview` on POST
- seed captured content even when the item already exists (not only when `created=true`)

## Behavior
- quick-add content works again for bookmarklet/share-target flows
- worker fetch success still wins later (`SeedCapturedContent` only applies before fetch success)

## Verification
- `go test ./internal/server ./internal/store`
- `go test ./...`
