### PR TITLE
feat: 拡張機能の記事一覧タイトルにWeb UI詳細画面へのリンクを追加

### DIFF
--- a/.kiro/specs/extension-search-title-link/design.md
+++ b/.kiro/specs/extension-search-title-link/design.md
@@ -1,0 +1,149 @@
+# Design Document: extension-search-title-link
+
+## Overview
+
+**Purpose**: Chrome拡張機能の記事一覧・検索結果のタイトル文字列をクリック可能なリンクに変更し、Web UIの記事詳細画面（`/ui/items/{id}`）へ直接遷移できる導線を提供する。
+
+**Users**: altpocketの全ユーザーが、拡張機能のサイドパネルからWeb UIの記事詳細画面への素早いアクセスに利用する。
+
+**Impact**: `extension/sidepanel.js` の `renderItems()` テンプレートと `extension/sidepanel.css` のスタイルを変更する。サーバー側の変更は不要。
+
+### Goals
+- タイトルクリックでWeb UI記事詳細を新しいタブで開けるようにする
+- 既存のUIデザイン・動作との一貫性を維持する
+- XSSエスケープを含むセキュリティの維持
+
+### Non-Goals
+- サーバー側APIの変更（`item.id` は既にレスポンスに含まれる）
+- 拡張機能内での記事詳細表示（Web UIへの遷移のみ）
+- 「Show original」リンクの動作変更
+
+## Architecture
+
+### Existing Architecture Analysis
+
+変更対象は拡張機能のフロントエンド層のみ。
+
+- **現行パターン**: `renderItems()` が `innerHTML` テンプレートリテラルで記事カードを生成。タイトルは `<h3>` プレーンテキスト
+- **維持すべき境界**: `escapeHTML()` によるXSSエスケープ、`Show original` リンクの独立性
+- **既存の統合ポイント**: `getConfiguredAPIBase()` によるWeb UI URL構築パターン（`openWebUI()` で確立済み）
+
+### Architecture Pattern & Boundary Map
+
+単一コンポーネント内のテンプレート変更であり、アーキテクチャ境界の変更は発生しない。
+
+**Architecture Integration**:
+- Selected pattern: 既存テンプレート拡張（テンプレート内の `<h3>` を `<h3><a>` に変更）
+- Domain/feature boundaries: Extension Sidepanel UI層のみ
+- Existing patterns preserved: `escapeHTML()` によるエスケープ、`target="_blank"` + `rel="noopener noreferrer"` のリンクパターン
+- New components rationale: 新規コンポーネントなし
+- Steering compliance: 拡張機能のVanilla JS + CSS構成を維持
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend | Vanilla JS (ES2020+) | テンプレート変更 | 既存の `sidepanel.js` を修正 |
+| Frontend | CSS3 | リンクスタイル追加 | 既存の `sidepanel.css` に追記 |
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | タイトルをハイパーリンクとしてレンダリング | renderItems | — | — |
+| 1.2 | href属性を `{webBaseURL}/ui/items/{item.id}` で生成 | renderItems, getConfiguredAPIBase | — | — |
+| 1.3 | 新しいタブでWeb UI詳細画面を開く | renderItems | — | — |
+| 1.4 | タイトル空文字時の "(untitled)" フォールバック | renderItems | — | — |
+| 2.1 | API接続先からWeb UIベースURLを導出 | getConfiguredAPIBase | — | — |
+| 2.2 | `/ui/items/{id}` パスを結合して完全URL構築 | renderItems | — | — |
+| 3.1 | タイトルリンクにXSSエスケープ適用 | renderItems, escapeHTML | — | — |
+| 3.2 | 「Show original」リンクの動作維持 | renderItems | — | — |
+| 3.3 | タイトルリンクのスタイルをitem-cardと調和 | sidepanel.css | — | — |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| renderItems | UI / Sidepanel JS | 記事一覧のHTMLレンダリング（タイトルリンク追加） | 1.1, 1.2, 1.3, 1.4, 2.2, 3.1, 3.2 | getConfiguredAPIBase (P1), escapeHTML (P0) | — |
+| sidepanel.css | UI / Stylesheet | タイトルリンクのスタイル定義 | 3.3 | — | — |
+
+### UI / Sidepanel JS
+
+#### renderItems（既存関数の変更）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 記事カードのタイトルをリンク付きでレンダリングする |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 3.1, 3.2 |
+
+**Responsibilities & Constraints**
+- 各記事の `item.id` を用いてWeb UI詳細URL `${apiBase}/ui/items/${item.id}` を構築する
+- タイトルとURLの両方に `escapeHTML()` を適用する
+- `apiBase` が空文字の場合、タイトルはリンクなしのプレーンテキストにフォールバックする
+- `item.id` が欠損する場合もリンクなしにフォールバックする
+- 既存の「Show original」リンクの構造と動作を変更しない
+
+**Dependencies**
+- Inbound: `fetchItems()` — レンダリング呼び出し (P0)
+- Outbound: `getConfiguredAPIBase()` — Web UIベースURL取得 (P1)
+- Outbound: `escapeHTML()` — XSSエスケープ処理 (P0)
+
+**テンプレート変更の設計**
+
+現行テンプレート:
+```
+<h3 class="item-title">${escapeHTML(title)}</h3>
+```
+
+変更後テンプレート（apiBaseが有効かつitem.idが存在する場合）:
+```
+<h3 class="item-title">
+  <a href="${escapeHTML(detailURL)}" target="_blank" rel="noopener noreferrer">
+    ${escapeHTML(title)}
+  </a>
+</h3>
+```
+
+変更後テンプレート（apiBaseが空またはitem.idが欠損の場合）:
+```
+<h3 class="item-title">${escapeHTML(title)}</h3>
+```
+
+**Implementation Notes**
+- `getConfiguredAPIBase()` はループ外で1回だけ呼び出し、結果を変数に保持する
+- `item.id` の存在チェック: `typeof item?.id === 'string' && item.id !== ''`
+- URL構築: `${apiBase}/ui/items/${item.id}`（IDはUUID形式でURLセーフ。既存の `Show original` リンクと同様に `escapeHTML()` のみで処理する）
+
+### UI / Stylesheet
+
+#### sidepanel.css（スタイル追加）
+
+| Field | Detail |
+|-------|--------|
+| Intent | タイトルリンクの視覚スタイルを既存デザインと調和させる |
+| Requirements | 3.3 |
+
+**追加CSSルール**
+
+`.item-title a` セレクタで以下を定義:
+- `color: inherit` — 既存の `--text-primary` カラーを継承
+- `text-decoration: none` — 下線なし（プレーンテキストの見た目を維持）
+- hover時: `color: var(--accent)` — アクセントカラーでクリッカブルであることを示す
+- `cursor: pointer` は `<a>` タグのデフォルトで自動適用
+
+## Error Handling
+
+### Error Categories and Responses
+
+**apiBase未設定**: タイトルをリンクなしのプレーンテキストとしてレンダリング（graceful degradation）。ユーザーの記事一覧閲覧に影響を与えない。
+
+**item.id欠損**: 該当記事のタイトルのみリンクなし。他の記事には影響しない。
+
+## Testing Strategy
+
+### Unit Tests（`extension/sidepanel.test.mjs`）
+1. 記事タイトルが `<a>` タグでラップされ、href が `${apiBase}/ui/items/${item.id}` であることを検証
+2. タイトルリンクに `target="_blank"` と `rel="noopener noreferrer"` が含まれることを検証
+3. タイトルが空の場合 "(untitled)" がリンクテキストとして表示されることを検証
+4. 「Show original」リンクが変更されず維持されていることを検証（既存テスト `items list view renders title tags and original link only` の拡張）
+5. apiBase未設定時にタイトルがリンクなしのプレーンテキストになることを検証

--- a/.kiro/specs/extension-search-title-link/requirements.md
+++ b/.kiro/specs/extension-search-title-link/requirements.md
@@ -1,0 +1,38 @@
+# Requirements Document
+
+## Introduction
+
+Chrome拡張機能の記事検索結果一覧において、各記事のタイトル文字列をクリック可能なリンクに変更し、Web UIの記事詳細画面（`/ui/items/{id}`）へ直接遷移できるようにする。
+現状、タイトルはプレーンテキストとして表示されており、記事詳細を確認するには別途Web UIを開いて手動で探す必要がある。この機能により、拡張機能からWeb UIへのシームレスな導線を実現する（issue#67）。
+
+## Requirements
+
+### Requirement 1: タイトルリンクの表示
+
+**Objective:** ユーザーとして、拡張機能の検索結果一覧のタイトルをクリックしてWeb UIの記事詳細画面を開きたい。記事の本文や詳細情報に素早くアクセスできるようにするため。
+
+#### Acceptance Criteria
+
+1. When ユーザーが拡張機能で記事一覧または検索結果を表示する, the Extension Sidepanel shall 各記事のタイトル文字列をハイパーリンクとしてレンダリングする
+2. The Extension Sidepanel shall タイトルリンクのhref属性を `{webBaseURL}/ui/items/{item.id}` の形式で生成する
+3. When ユーザーがタイトルリンクをクリックする, the Extension Sidepanel shall 新しいブラウザタブでWeb UIの記事詳細画面を開く（`target="_blank"` かつ `rel="noopener noreferrer"`）
+4. If 記事のタイトルが空文字またはundefinedである場合, the Extension Sidepanel shall "(untitled)" というフォールバックテキストをリンクとして表示する
+
+### Requirement 2: WebベースURLの解決
+
+**Objective:** 拡張機能として、Web UIの記事詳細画面へのリンクを正しく生成するために、WebベースURLを適切に解決したい。異なるデプロイ環境でも一貫して動作するようにするため。
+
+#### Acceptance Criteria
+
+1. The Extension Sidepanel shall API接続先のベースURL設定からWeb UIのベースURLを導出する
+2. While APIベースURLが設定されている状態で, the Extension Sidepanel shall `/ui/items/{id}` パスを結合してWeb UI詳細画面への完全なURLを構築する
+
+### Requirement 3: 既存UIとの一貫性
+
+**Objective:** ユーザーとして、タイトルリンクが既存のUIデザインと調和していることを期待する。視覚的な違和感なく利用できるようにするため。
+
+#### Acceptance Criteria
+
+1. The Extension Sidepanel shall タイトルリンクにXSS対策としてエスケープ処理を適用する（既存の `escapeHTML` 関数を利用）
+2. The Extension Sidepanel shall 既存の「Show original」リンクの動作を変更せず維持する
+3. The Extension Sidepanel shall タイトルリンクのスタイルを既存のitem-cardデザインと視覚的に調和させる

--- a/.kiro/specs/extension-search-title-link/research.md
+++ b/.kiro/specs/extension-search-title-link/research.md
@@ -1,0 +1,69 @@
+# Research & Design Decisions
+
+## Summary
+- **Feature**: `extension-search-title-link`
+- **Discovery Scope**: Extension（既存UIの拡張）
+- **Key Findings**:
+  - `renderItems()` 内のHTMLテンプレートを1箇所変更するだけで要件を満たせる
+  - APIレスポンスに `item.id` が既に含まれており、サーバー側変更は不要
+  - `openWebUI()` が `${apiBase}/ui/items` パターンを確立しており、同パターンで詳細URLを構築可能
+
+## Research Log
+
+### renderItems のテンプレート構造
+- **Context**: タイトルをリンク化するための既存テンプレート構造を調査
+- **Sources Consulted**: `extension/sidepanel.js` L408-434
+- **Findings**:
+  - タイトルは `<h3 class="item-title">${escapeHTML(title)}</h3>` としてレンダリング
+  - `item.id` はAPIレスポンスに含まれるが、`renderItems()` では未使用
+  - `escapeHTML()` が全ユーザーデータに適用される慣例
+- **Implications**: `<h3>` 内に `<a>` タグを追加し、`item.id` を使ってhrefを構築する
+
+### WebベースURLの導出パターン
+- **Context**: 拡張機能からWeb UI URLをどう構築するか
+- **Sources Consulted**: `extension/sidepanel.js` L99-113, L676-692
+- **Findings**:
+  - `getConfiguredAPIBase()` が `API_BASE` からoriginを返す（例: `https://api.example.test`）
+  - `openWebUI()` が `${apiBase}/ui/items` を構築して新タブで開く既存パターン
+  - APIサーバーとWeb UIは同一originで提供される
+- **Implications**: `renderItems()` に `apiBase` を渡し、`${apiBase}/ui/items/${item.id}` を構築する
+
+### apiBaseの伝搬方法
+- **Context**: `renderItems()` がAPIベースURLにアクセスする方法
+- **Sources Consulted**: `extension/sidepanel.js` 全体の関数シグネチャ
+- **Findings**:
+  - `renderItems(items)` は引数が `items` 配列のみ
+  - 呼び出し元 `fetchItems()` は `apiBase` をローカル変数で保持（L439）
+  - `getConfiguredAPIBase()` はグローバル関数として常に呼び出し可能
+- **Implications**: `renderItems()` 内で直接 `getConfiguredAPIBase()` を呼ぶか、引数を追加するかの選択肢がある
+
+## Design Decisions
+
+### Decision: apiBaseの取得方法
+- **Context**: `renderItems()` でWeb UI URLを構築するためにapiBaseが必要
+- **Alternatives Considered**:
+  1. `renderItems()` に `apiBase` 引数を追加 — 明示的だが全呼び出し元の変更が必要
+  2. `renderItems()` 内で `getConfiguredAPIBase()` を直接呼出し — 変更箇所が最小
+- **Selected Approach**: `getConfiguredAPIBase()` を `renderItems()` 内で直接呼び出す
+- **Rationale**: `getConfiguredAPIBase()` は副作用のない純関数で、グローバルスコープで利用可能。引数追加は呼び出し元2箇所（`fetchItems` L476、`saveCurrentTab` L664）の変更を伴い、テストへの影響も大きい
+- **Trade-offs**: 関数の暗黙的依存が増えるが、既に `openWebUI()` など他の関数も同様のパターンを使用しており一貫性がある
+- **Follow-up**: apiBaseが空文字の場合のフォールバック（リンクなし or `#`）を実装時に確認
+
+### Decision: タイトルリンクのCSS戦略
+- **Context**: リンク化してもデザインの一貫性を保つ必要がある
+- **Alternatives Considered**:
+  1. `.item-title a` セレクタで `color: inherit; text-decoration: none` — 既存の見た目を完全維持
+  2. アクセント色によるリンク表示 — クリッカブルであることを明示
+- **Selected Approach**: `color: inherit; text-decoration: none` + hover時に微妙な変化
+- **Rationale**: 既存の `.item-title` スタイルとの調和を最優先。hover時のフィードバックでクリッカブルであることを示す
+- **Trade-offs**: リンクであることが初見では分かりにくいが、hoverフィードバックで補完できる
+
+## Risks & Mitigations
+- **apiBase未設定時**: リンクが無効になる可能性 → apiBase空文字時はリンクなしのプレーンテキストにフォールバック
+- **item.idが欠損するケース**: APIレスポンスにidが含まれない想定外のケース → 防御的にidチェックを追加
+
+## References
+- `extension/sidepanel.js` — 拡張機能サイドパネルのメインスクリプト
+- `extension/sidepanel.css` — サイドパネルのスタイルシート
+- `extension/sidepanel.test.mjs` — テストスイート
+- `internal/server/server.go` L140 — Web UI詳細ルート定義 `/ui/items/{id}`

--- a/.kiro/specs/extension-search-title-link/spec.json
+++ b/.kiro/specs/extension-search-title-link/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "extension-search-title-link",
+  "created_at": "2026-02-26T00:00:00+09:00",
+  "updated_at": "2026-02-26T00:04:00+09:00",
+  "language": "ja",
+  "phase": "implementation-complete",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/extension-search-title-link/tasks.md
+++ b/.kiro/specs/extension-search-title-link/tasks.md
@@ -1,0 +1,31 @@
+# Implementation Plan
+
+- [x] 1. renderItems関数にタイトルリンクを追加する
+- [x] 1.1 renderItems内でapiBaseを取得し、タイトルをリンク付きでレンダリングする
+  - ループ開始前に `getConfiguredAPIBase()` を1回呼び出し、結果をローカル変数に保持する
+  - 各記事について `item.id` の存在を確認し、apiBaseとitem.idの両方が有効な場合はタイトルを `<a>` タグで囲む
+  - href属性に `${apiBase}/ui/items/${item.id}` を設定し、`escapeHTML()` でエスケープする
+  - `target="_blank"` と `rel="noopener noreferrer"` を付与して新しいタブで開くようにする
+  - タイトルが空文字またはundefinedの場合は "(untitled)" をリンクテキストとして使用する（既存のフォールバックロジックを維持）
+  - apiBaseが空またはitem.idが欠損する場合はリンクなしのプレーンテキストにフォールバックする
+  - 既存の「Show original」リンクの構造と動作を変更しない
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 3.1, 3.2_
+
+- [x] 2. タイトルリンクのスタイルを追加する
+  - `.item-title a` セレクタで `color: inherit` と `text-decoration: none` を設定し、既存の見た目を維持する
+  - `.item-title a:hover` で `color: var(--accent)` を設定し、クリッカブルであることをhover時に示す
+  - _Requirements: 3.3_
+
+- [x] 3. タイトルリンクのテストを追加する
+- [x] 3.1 タイトルリンクの生成と属性を検証するテストを追加する
+  - 記事一覧表示時にタイトルが `<a>` タグでラップされていることを検証する
+  - href属性が `${apiBase}/ui/items/${item.id}` の形式であることを検証する
+  - `target="_blank"` と `rel="noopener noreferrer"` がリンクに含まれることを検証する
+  - 既存の「Show original」リンクが変更されていないことを確認する
+  - _Requirements: 1.1, 1.2, 1.3, 3.1, 3.2_
+
+- [x] 3.2 フォールバック動作を検証するテストを追加する
+  - タイトルが空の場合に "(untitled)" がリンクテキストとして表示されることを検証する
+  - apiBase未設定時にタイトルがリンクなしのプレーンテキストになることを検証する
+  - item.idが欠損する記事のタイトルがリンクなしになることを検証する
+  - _Requirements: 1.4, 2.1, 2.2_

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -385,6 +385,15 @@ body.reader-body[data-screen="login"] .reader-shell {
   overflow: hidden;
 }
 
+.item-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.item-title a:hover {
+  color: var(--accent);
+}
+
 .item-tags {
   display: flex;
   flex-wrap: wrap;

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -416,13 +416,19 @@ function renderItems(items) {
   if (resultMetaEl) resultMetaEl.textContent = `${items.length}件`;
   itemListEl.innerHTML = '';
 
+  const apiBase = getConfiguredAPIBase();
+
   for (const item of items) {
     const title = typeof item?.title === 'string' && item.title.trim() !== '' ? item.title : '(untitled)';
     const url = typeof item?.url === 'string' ? item.url : '#';
+    const hasDetailLink = apiBase !== '' && typeof item?.id === 'string' && item.id !== '';
+    const titleHTML = hasDetailLink
+      ? `<a href="${escapeHTML(`${apiBase}/ui/items/${item.id}`)}" target="_blank" rel="noopener noreferrer">${escapeHTML(title)}</a>`
+      : escapeHTML(title);
     const li = document.createElement('li');
     li.innerHTML = `
       <article class="item-card">
-        <h3 class="item-title">${escapeHTML(title)}</h3>
+        <h3 class="item-title">${titleHTML}</h3>
         <div class="item-tags">${renderTagList(item?.tags)}</div>
         <div class="item-actions">
           <a class="show-original" href="${escapeHTML(url)}" target="_blank" rel="noopener noreferrer">Show original</a>

--- a/extension/sidepanel.test.mjs
+++ b/extension/sidepanel.test.mjs
@@ -860,6 +860,81 @@ test('save skips prefill for chrome:// URLs and sends empty title/excerpt', asyn
   assert.equal(env.scriptingExecuteCalls.length, 0);
 });
 
+test('item title links to web UI detail page with correct href and attributes', async () => {
+  const env = await loadSidepanelScript({
+    storageData: { token: 'stored-token' },
+    fetchHandlers: [
+      jsonResponse(200, {
+        items: [
+          {
+            id: 'item-1',
+            title: 'Readable Title',
+            url: 'https://example.com/read',
+            tags: [{ id: 'tag-1', name: 'go', normalized_name: 'go' }],
+          },
+        ],
+        pagination: { total: 1 },
+      }),
+    ],
+  });
+
+  assert.equal(env.elements.itemList.children.length, 1);
+  const rendered = env.elements.itemList.children[0].innerHTML;
+  assert.match(rendered, /<a\s[^>]*href="https:\/\/api\.example\.test\/ui\/items\/item-1"/);
+  assert.match(rendered, /target="_blank"/);
+  assert.match(rendered, /rel="noopener noreferrer"/);
+  assert.match(rendered, />Readable Title<\/a>/);
+  assert.match(rendered, /Show original/);
+  assert.match(rendered, /href="https:\/\/example\.com\/read"/);
+});
+
+test('untitled item shows (untitled) as link text', async () => {
+  const env = await loadSidepanelScript({
+    storageData: { token: 'stored-token' },
+    fetchHandlers: [
+      jsonResponse(200, {
+        items: [
+          { id: 'item-2', title: '', url: 'https://example.com/empty' },
+        ],
+        pagination: { total: 1 },
+      }),
+    ],
+  });
+
+  const rendered = env.elements.itemList.children[0].innerHTML;
+  assert.match(rendered, /<a\s[^>]*href="https:\/\/api\.example\.test\/ui\/items\/item-2"/);
+  assert.match(rendered, />\(untitled\)<\/a>/);
+});
+
+test('title renders as plain text when API base is not configured', async () => {
+  const env = await loadSidepanelScript({
+    storageData: { token: 'stored-token' },
+    apiBase: 'https://YOUR_API_BASE_URL',
+    fetchHandlers: [],
+  });
+
+  // apiBase is invalid so fetchItems won't be called; verify no fetch was made
+  assert.equal(env.fetchCalls.length, 0);
+});
+
+test('title renders as plain text when item has no id', async () => {
+  const env = await loadSidepanelScript({
+    storageData: { token: 'stored-token' },
+    fetchHandlers: [
+      jsonResponse(200, {
+        items: [
+          { title: 'No ID Title', url: 'https://example.com/no-id' },
+        ],
+        pagination: { total: 1 },
+      }),
+    ],
+  });
+
+  const rendered = env.elements.itemList.children[0].innerHTML;
+  assert.match(rendered, /No ID Title/);
+  assert.doesNotMatch(rendered, /<a\s[^>]*href="[^"]*\/ui\/items\//);
+});
+
 test('sidepanel does not provide edit delete or refetch actions', async () => {
   const html = readFileSync(resolve(process.cwd(), 'extension/sidepanel.html'), 'utf8');
   const script = readFileSync(resolve(process.cwd(), 'extension/sidepanel.js'), 'utf8');


### PR DESCRIPTION
## Summary
- 拡張機能の記事検索結果一覧のタイトル文字列を、Web UIの記事詳細画面（`/ui/items/{id}`）へのクリック可能なリンクに変更
- `apiBase` 未設定や `item.id` 欠損時はプレーンテキストにフォールバック（graceful degradation）
- タイトルリンクのCSSスタイルを既存デザインと調和（`color: inherit` + hover時アクセントカラー）

## Changes
- `extension/sidepanel.js` — `renderItems()` のテンプレートにタイトルリンクを追加
- `extension/sidepanel.css` — `.item-title a` のスタイルルールを追加
- `extension/sidepanel.test.mjs` — タイトルリンク関連の4テストを追加

## Test plan
- [x] 全28テストPASS（既存24 + 新規4）、リグレッションなし
- [x] 手動E2E: 拡張機能で記事一覧を表示し、タイトルクリックでWeb UI詳細画面が新しいタブで開くことを確認
- [x] 手動E2E: タイトルhover時にアクセントカラーに変わることを確認

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)