### PR TITLE
feat: Extension sliding session & LP landing page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "api",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "DATABASE_URL=postgres://altpocket:altpocket@localhost:5432/altpocket?sslmode=disable",
+        "SESSION_SECRET=dev-secret",
+        "JWT_SECRET=dev-jwt-secret",
+        "GOOGLE_WEB_CLIENT_ID=dummy",
+        "GOOGLE_EXT_CLIENT_ID=dummy",
+        "GOOGLE_CLIENT_SECRET=dummy",
+        "PUBLIC_BASE_URL=http://localhost:8080",
+        "go", "run", "./cmd/api"
+      ],
+      "port": 8080
+    }
+  ]
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -46,6 +46,7 @@ func main() {
 		select {
 		case <-ticker.C:
 			cleanupSessions(ctx, st, log)
+			cleanupRefreshTokens(ctx, st, log)
 			runOnce(ctx, st, f, log)
 		case <-done:
 			log.Info("worker_shutdown")
@@ -62,6 +63,17 @@ func cleanupSessions(ctx context.Context, st *store.Store, log *slog.Logger) {
 	}
 	if removed > 0 {
 		log.Info("session_cleanup", "removed", removed)
+	}
+}
+
+func cleanupRefreshTokens(ctx context.Context, st *store.Store, log *slog.Logger) {
+	removed, err := st.CleanupExpiredExtensionRefreshTokens(ctx)
+	if err != nil {
+		log.Error("refresh_token_cleanup_failed", "error", err)
+		return
+	}
+	if removed > 0 {
+		log.Info("refresh_token_cleanup", "removed", removed)
 	}
 }
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -19,6 +19,7 @@ const itemListEl = document.getElementById('itemList');
 
 const appState = {
   token: '',
+  refreshToken: '',
   tags: [],
   searchTimer: null,
   lastFetchID: 0,
@@ -220,7 +221,31 @@ async function clearStoredToken() {
   }
 }
 
-function createExtensionAPIClient({ getToken, onAuthFailure }) {
+function createExtensionAPIClient({ getToken, getRefreshToken, onTokenRefreshed, onAuthFailure }) {
+  let refreshPromise = null;
+
+  async function tryRefresh(apiBase) {
+    const rt = getRefreshToken();
+    if (!rt) return false;
+    try {
+      const res = await fetch(`${apiBase}/v1/auth/extension/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: rt }),
+      });
+      if (!res.ok) return false;
+      const text = await res.text();
+      let body;
+      try { body = JSON.parse(text); } catch { return false; }
+      const newToken = typeof body?.token === 'string' ? body.token.trim() : '';
+      if (newToken === '') return false;
+      await onTokenRefreshed(newToken);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async function requestJSON(url, options = {}, requestOptions = {}) {
     const { auth = true, authFailure = true } = requestOptions;
     const headers = options.headers ? { ...options.headers } : {};
@@ -242,6 +267,32 @@ function createExtensionAPIClient({ getToken, onAuthFailure }) {
         data: null,
         networkError,
       };
+    }
+
+    // On 401, attempt a transparent token refresh and retry once.
+    if (res.status === 401 && auth && authFailure) {
+      const apiBase = getConfiguredAPIBase();
+      if (apiBase) {
+        if (!refreshPromise) {
+          refreshPromise = tryRefresh(apiBase).finally(() => {
+            refreshPromise = null;
+          });
+        }
+        const refreshed = await refreshPromise;
+        if (refreshed) {
+          // Retry with the new token.
+          const retryHeaders = options.headers ? { ...options.headers } : {};
+          const newToken = getToken();
+          if (newToken) {
+            retryHeaders.Authorization = `Bearer ${newToken}`;
+          }
+          try {
+            res = await fetch(url, { ...options, headers: retryHeaders });
+          } catch (networkError) {
+            return { ok: false, status: 0, data: null, networkError };
+          }
+        }
+      }
     }
 
     const { data } = await readResponseBody(res);
@@ -266,6 +317,18 @@ function createExtensionAPIClient({ getToken, onAuthFailure }) {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ id_token: idToken }),
+        },
+        { auth: false, authFailure: false },
+      );
+    },
+
+    revokeRefreshToken(apiBase, refreshToken) {
+      return requestJSON(
+        `${apiBase}/v1/auth/extension/logout`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token: refreshToken }),
         },
         { auth: false, authFailure: false },
       );
@@ -749,8 +812,12 @@ async function login() {
       return;
     }
 
+    const exchangedRefresh = typeof exchange.data?.refresh_token === 'string' ? exchange.data.refresh_token.trim() : '';
     appState.token = exchangedToken;
-    await chrome.storage.local.set({ token: appState.token });
+    appState.refreshToken = exchangedRefresh;
+    const storagePayload = { token: appState.token };
+    if (exchangedRefresh) storagePayload.refresh_token = exchangedRefresh;
+    await chrome.storage.local.set(storagePayload);
     showReaderScreen();
     await fetchItems('');
   } catch {
@@ -769,7 +836,15 @@ async function logout(options = {}) {
   if (signOutBtn) signOutBtn.disabled = true;
 
   try {
+    // Revoke refresh token on the server (best-effort).
+    const apiBase = getConfiguredAPIBase();
+    const rt = appState.refreshToken;
+    if (apiBase && rt) {
+      await apiClient.revokeRefreshToken(apiBase, rt).catch(() => {});
+    }
+
     await clearStoredToken();
+    appState.refreshToken = '';
     if (chrome.identity && typeof chrome.identity.clearAllCachedAuthTokens === 'function') {
       await chrome.identity.clearAllCachedAuthTokens();
     }
@@ -788,6 +863,14 @@ async function handleAuthFailure() {
 
 const apiClient = createExtensionAPIClient({
   getToken: () => getSessionToken(),
+  getRefreshToken: () => {
+    if (typeof appState.refreshToken !== 'string') return '';
+    return appState.refreshToken.trim();
+  },
+  onTokenRefreshed: async (newToken) => {
+    appState.token = newToken;
+    await chrome.storage.local.set({ token: newToken });
+  },
   onAuthFailure: handleAuthFailure,
 });
 
@@ -849,10 +932,12 @@ if (searchInputEl) {
 
 (async () => {
   try {
-    const data = await chrome.storage.local.get(['token']);
+    const data = await chrome.storage.local.get(['token', 'refresh_token']);
     const storedToken = typeof data?.token === 'string' ? data.token.trim() : '';
+    const storedRefresh = typeof data?.refresh_token === 'string' ? data.refresh_token.trim() : '';
     if (storedToken !== '') {
       appState.token = storedToken;
+      appState.refreshToken = storedRefresh;
       showReaderScreen();
       await fetchItems('');
       return;

--- a/extension/sidepanel.test.mjs
+++ b/extension/sidepanel.test.mjs
@@ -538,10 +538,14 @@ test('save current tab posts item with prefill and sends async capture for newly
   assert.equal(env.elements.utilityStatus.classList.contains('is-success'), true);
 });
 
-test('401 during items fetch logs out and returns to login screen', async () => {
+test('401 during items fetch with failed refresh logs out and returns to login screen', async () => {
   const env = await loadSidepanelScript({
     storageData: { token: 'expired-token', refresh_token: 'r1', keep: 'ok' },
-    fetchHandlers: [jsonResponse(401, { error: 'unauthorized' })],
+    fetchHandlers: [
+      jsonResponse(401, { error: 'unauthorized' }),
+      // Refresh attempt also fails (expired refresh token).
+      jsonResponse(401, { error: 'invalid_token' }),
+    ],
   });
 
   await flushMicrotasks();
@@ -553,7 +557,34 @@ test('401 during items fetch logs out and returns to login screen', async () => 
   assert.equal(env.storageData.keep, 'ok');
 });
 
-test('manual sign-out clears all token-like keys and returns to login-only screen', async () => {
+test('401 during items fetch with successful refresh retries and stays on reader screen', async () => {
+  const env = await loadSidepanelScript({
+    storageData: { token: 'expired-token', refresh_token: 'valid-refresh' },
+    fetchHandlers: [
+      // First items fetch returns 401.
+      jsonResponse(401, { error: 'unauthorized' }),
+      // Refresh succeeds with a new token.
+      jsonResponse(200, { token: 'new-jwt-token', expires_in: 3600 }),
+      // Retry items fetch succeeds.
+      jsonResponse(200, { items: [], pagination: { total: 0 } }),
+    ],
+  });
+
+  await flushMicrotasks();
+
+  assert.equal(env.document.body.dataset.screen, 'reader');
+  // The refresh call was made.
+  assert.equal(env.fetchCalls.length, 3);
+  assert.equal(env.fetchCalls[1].url, 'https://api.example.test/v1/auth/extension/refresh');
+  const refreshPayload = JSON.parse(env.fetchCalls[1].options.body);
+  assert.equal(refreshPayload.refresh_token, 'valid-refresh');
+  // The retry used the new token.
+  assert.equal(env.fetchCalls[2].options.headers.Authorization, 'Bearer new-jwt-token');
+  // Storage was updated with new token.
+  assert.equal(env.storageSetCalls.some((c) => c.token === 'new-jwt-token'), true);
+});
+
+test('manual sign-out revokes refresh token on server and clears all token-like keys', async () => {
   const env = await loadSidepanelScript({
     storageData: {
       token: 'stored-token',
@@ -561,19 +592,46 @@ test('manual sign-out clears all token-like keys and returns to login-only scree
       sessionToken: 'session-like',
       keep: 'safe',
     },
-    fetchHandlers: [jsonResponse(200, { items: [], pagination: { total: 0 } })],
+    fetchHandlers: [
+      jsonResponse(200, { items: [], pagination: { total: 0 } }),
+      // Server-side refresh token revocation (logout endpoint).
+      jsonResponse(204, ''),
+    ],
   });
 
   await env.elements.signOut.click();
   await flushMicrotasks();
 
   assert.equal(env.document.body.dataset.screen, 'login');
+  // Verify the logout endpoint was called with the refresh token.
+  const logoutCall = env.fetchCalls.find((c) => c.url.includes('/v1/auth/extension/logout'));
+  assert.ok(logoutCall, 'logout endpoint should be called');
+  const logoutPayload = JSON.parse(logoutCall.options.body);
+  assert.equal(logoutPayload.refresh_token, 'refresh');
+  // Verify storage cleanup.
   assert.equal(env.storageRemoveCalls.length, 1);
   assert.equal(env.storageRemoveCalls[0].includes('token'), true);
   assert.equal(env.storageRemoveCalls[0].includes('refresh_token'), true);
   assert.equal(env.storageRemoveCalls[0].includes('sessionToken'), true);
   assert.equal(env.storageData.keep, 'safe');
   assert.equal(env.clearAuthTokenCalls.length, 1);
+});
+
+test('login stores refresh_token from exchange response', async () => {
+  const env = await loadSidepanelScript({
+    fetchHandlers: [
+      jsonResponse(200, { token: 'jwt-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+      jsonResponse(200, { items: [], pagination: { total: 0 } }),
+    ],
+  });
+
+  await env.elements.login.click();
+  await flushMicrotasks();
+
+  assert.equal(env.document.body.dataset.screen, 'reader');
+  assert.equal(env.storageSetCalls.length, 1);
+  assert.equal(env.storageSetCalls[0].token, 'jwt-token');
+  assert.equal(env.storageSetCalls[0].refresh_token, 'new-refresh');
 });
 
 test('init with token and missing API permission shows guidance and skips list fetch', async () => {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,3 +92,14 @@ func getEnvInt(key string, fallback int) int {
 func SessionTTL() time.Duration {
 	return 7 * 24 * time.Hour
 }
+
+// ExtensionJWTTTL is the lifetime of short-lived JWTs issued for the Chrome extension.
+func ExtensionJWTTTL() time.Duration {
+	return 1 * time.Hour
+}
+
+// ExtensionRefreshTokenTTL is the sliding-window lifetime of extension refresh tokens.
+// The expiration is extended by this duration on each use.
+func ExtensionRefreshTokenTTL() time.Duration {
+	return 30 * 24 * time.Hour
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -122,6 +124,8 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/auth/google/login", s.handleGoogleLogin)
 		r.Get("/auth/google/callback", s.handleGoogleCallback)
 		r.Post("/auth/extension/exchange", s.handleExtensionExchange)
+		r.Post("/auth/extension/refresh", s.handleExtensionRefresh)
+		r.Post("/auth/extension/logout", s.handleExtensionLogout)
 		r.Get("/tags", s.requireAuth(s.handleTags))
 
 		r.Route("/items", func(r chi.Router) {
@@ -171,12 +175,11 @@ func (s *Server) handleServiceWorker(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
-	if _, _, ok := s.webSession(r); ok {
-		http.Redirect(w, r, "/ui/items", http.StatusFound)
-		return
-	}
 	data := map[string]interface{}{
-		"Title": "ログイン",
+		"Title": "altpocket",
+	}
+	if _, user, ok := s.webSession(r); ok {
+		data["User"] = user
 	}
 	if err := s.renderer.Render(w, "home", data); err != nil {
 		http.Error(w, "render error", http.StatusInternalServerError)
@@ -352,16 +355,94 @@ func (s *Server) handleExtensionExchange(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	token, exp, err := auth.IssueJWT(s.cfg.JWTSecret, user.ID, 24*time.Hour)
+	token, exp, err := auth.IssueJWT(s.cfg.JWTSecret, user.ID, config.ExtensionJWTTTL())
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token_error"})
 		return
+	}
+
+	// Issue a refresh token (opaque random string, stored hashed in DB).
+	rawRefresh, err := s.randomString(32)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token_error"})
+		return
+	}
+	refreshHash := hashToken(rawRefresh)
+	_, err = s.store.CreateExtensionRefreshToken(r.Context(), user.ID, refreshHash, config.ExtensionRefreshTokenTTL())
+	if err != nil {
+		s.logger.Error("auth.extension.exchange.refresh_token_create_failed",
+			slog.String("error", err.Error()))
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token_error"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"token":         token,
+		"expires_in":    exp - time.Now().Unix(),
+		"refresh_token": rawRefresh,
+	})
+}
+
+func (s *Server) handleExtensionRefresh(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.RefreshToken == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	refreshHash := hashToken(req.RefreshToken)
+	rt, err := s.store.GetExtensionRefreshToken(r.Context(), refreshHash)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid_token"})
+		return
+	}
+
+	// Issue a new short-lived JWT.
+	user, err := s.store.GetUserByID(r.Context(), rt.UserID)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid_token"})
+		return
+	}
+
+	token, exp, err := auth.IssueJWT(s.cfg.JWTSecret, user.ID, config.ExtensionJWTTTL())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token_error"})
+		return
+	}
+
+	// Slide the refresh token expiration forward.
+	if err := s.store.TouchExtensionRefreshToken(r.Context(), rt.ID, config.ExtensionRefreshTokenTTL()); err != nil {
+		s.logger.Error("auth.extension.refresh.touch_failed",
+			slog.String("error", err.Error()))
+		// Non-fatal: the new JWT is already issued, so continue.
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"token":      token,
 		"expires_in": exp - time.Now().Unix(),
 	})
+}
+
+func (s *Server) handleExtensionLogout(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.RefreshToken == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	refreshHash := hashToken(req.RefreshToken)
+	_ = s.store.DeleteExtensionRefreshToken(r.Context(), refreshHash)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// hashToken returns the hex-encoded SHA-256 hash of a raw token string.
+func hashToken(raw string) string {
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
 }
 
 func (s *Server) handleTags(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/refresh_token.go
+++ b/internal/store/refresh_token.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+type ExtensionRefreshToken struct {
+	ID         string
+	UserID     string
+	TokenHash  string
+	ExpiresAt  time.Time
+	CreatedAt  time.Time
+	LastUsedAt time.Time
+}
+
+// CreateExtensionRefreshToken inserts a new refresh token record.
+func (s *Store) CreateExtensionRefreshToken(ctx context.Context, userID, tokenHash string, ttl time.Duration) (ExtensionRefreshToken, error) {
+	ttlSeconds := int64(ttl.Seconds())
+	row := s.DB.QueryRow(ctx, `
+		INSERT INTO extension_refresh_tokens (user_id, token_hash, expires_at)
+		VALUES ($1, $2, NOW() + ($3::bigint * INTERVAL '1 second'))
+		RETURNING id, user_id, token_hash, expires_at, created_at, last_used_at
+	`, userID, tokenHash, ttlSeconds)
+	var rt ExtensionRefreshToken
+	if err := row.Scan(&rt.ID, &rt.UserID, &rt.TokenHash, &rt.ExpiresAt, &rt.CreatedAt, &rt.LastUsedAt); err != nil {
+		return ExtensionRefreshToken{}, err
+	}
+	return rt, nil
+}
+
+// GetExtensionRefreshToken retrieves a valid (non-expired) refresh token by its hash.
+func (s *Store) GetExtensionRefreshToken(ctx context.Context, tokenHash string) (ExtensionRefreshToken, error) {
+	row := s.DB.QueryRow(ctx, `
+		SELECT id, user_id, token_hash, expires_at, created_at, last_used_at
+		FROM extension_refresh_tokens
+		WHERE token_hash = $1 AND expires_at > NOW()
+	`, tokenHash)
+	var rt ExtensionRefreshToken
+	if err := row.Scan(&rt.ID, &rt.UserID, &rt.TokenHash, &rt.ExpiresAt, &rt.CreatedAt, &rt.LastUsedAt); err != nil {
+		return ExtensionRefreshToken{}, err
+	}
+	return rt, nil
+}
+
+// TouchExtensionRefreshToken extends the expiration (sliding window) and updates last_used_at.
+func (s *Store) TouchExtensionRefreshToken(ctx context.Context, id string, ttl time.Duration) error {
+	ttlSeconds := int64(ttl.Seconds())
+	_, err := s.DB.Exec(ctx, `
+		UPDATE extension_refresh_tokens
+		SET last_used_at = NOW(),
+		    expires_at = NOW() + ($2::bigint * INTERVAL '1 second')
+		WHERE id = $1
+	`, id, ttlSeconds)
+	return err
+}
+
+// DeleteExtensionRefreshToken removes a single refresh token (for logout).
+func (s *Store) DeleteExtensionRefreshToken(ctx context.Context, tokenHash string) error {
+	_, err := s.DB.Exec(ctx, `DELETE FROM extension_refresh_tokens WHERE token_hash = $1`, tokenHash)
+	return err
+}
+
+// DeleteExtensionRefreshTokensByUser removes all refresh tokens for a user.
+func (s *Store) DeleteExtensionRefreshTokensByUser(ctx context.Context, userID string) error {
+	_, err := s.DB.Exec(ctx, `DELETE FROM extension_refresh_tokens WHERE user_id = $1`, userID)
+	return err
+}
+
+// CleanupExpiredExtensionRefreshTokens removes all expired refresh tokens.
+func (s *Store) CleanupExpiredExtensionRefreshTokens(ctx context.Context) (int64, error) {
+	ct, err := s.DB.Exec(ctx, `DELETE FROM extension_refresh_tokens WHERE expires_at <= NOW()`)
+	if err != nil {
+		return 0, err
+	}
+	return ct.RowsAffected(), nil
+}

--- a/migrations/003_extension_refresh_tokens.sql
+++ b/migrations/003_extension_refresh_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE extension_refresh_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ext_refresh_tokens_user ON extension_refresh_tokens(user_id);
+CREATE INDEX idx_ext_refresh_tokens_expires ON extension_refresh_tokens(expires_at);

--- a/static/style.css
+++ b/static/style.css
@@ -1748,6 +1748,323 @@ p.muted {
 }
 
 /* =============================================
+   Landing Page
+   ============================================= */
+.lp-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 var(--space-6);
+}
+
+/* Hero */
+.lp-hero {
+  padding: var(--space-16) 0;
+  text-align: center;
+}
+
+.lp-hero-eyebrow {
+  margin: 0 0 var(--space-3);
+  color: var(--color-primary);
+  font-size: var(--type-subhead-size);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.lp-hero-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 40px;
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.lp-hero-desc {
+  margin: var(--space-4) auto 0;
+  max-width: 480px;
+  font-size: var(--type-headline-size);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.lp-hero-actions {
+  margin-top: var(--space-8);
+  display: flex;
+  gap: var(--space-3);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.lp-hero-actions .btn-primary,
+.lp-hero-actions .btn-secondary {
+  min-width: 200px;
+  height: 48px;
+  font-size: var(--type-headline-size);
+}
+
+/* Sections */
+.lp-section {
+  padding: var(--space-16) 0;
+}
+
+.lp-section--alt {
+  background: var(--bg-surface);
+}
+
+.lp-section-title {
+  margin: 0 0 var(--space-10);
+  font-family: var(--font-display);
+  font-size: var(--type-title-1-size);
+  font-weight: 700;
+  text-align: center;
+  color: var(--text-primary);
+}
+
+/* Features Grid */
+.lp-features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.lp-feature-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--separator);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  text-align: center;
+}
+
+.lp-section--alt .lp-feature-card {
+  background: var(--bg-elevated);
+}
+
+.lp-feature-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  margin-bottom: var(--space-4);
+}
+
+.lp-feature-card h3 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--type-headline-size);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.lp-feature-card p {
+  margin: 0;
+  font-size: var(--type-body-size);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* Steps */
+.lp-steps {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--space-4);
+}
+
+.lp-step {
+  flex: 1;
+  max-width: 240px;
+  text-align: center;
+}
+
+.lp-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  color: #fff;
+  font-size: var(--type-headline-size);
+  font-weight: 700;
+  margin-bottom: var(--space-3);
+}
+
+.lp-step h3 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--type-headline-size);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.lp-step p {
+  margin: 0;
+  font-size: var(--type-body-size);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.lp-step-arrow {
+  flex-shrink: 0;
+  margin-top: 12px;
+  color: var(--text-tertiary);
+}
+
+/* Use cases */
+.lp-usecases {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.lp-usecase {
+  padding: var(--space-5);
+  border-left: 3px solid var(--color-primary);
+}
+
+.lp-usecase h3 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--type-headline-size);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.lp-usecase p {
+  margin: 0;
+  font-size: var(--type-body-size);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* CTA */
+.lp-cta {
+  text-align: center;
+  background: var(--color-primary-soft);
+}
+
+.lp-cta-title {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-display);
+  font-size: var(--type-title-2-size);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.lp-cta-desc {
+  margin: 0;
+  font-size: var(--type-body-size);
+  color: var(--text-secondary);
+}
+
+/* Footer */
+.lp-footer {
+  padding: var(--space-8) 0;
+  border-top: 1px solid var(--separator);
+}
+
+.lp-footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.lp-footer-brand {
+  font-family: var(--font-display);
+  font-size: var(--type-headline-size);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.lp-footer-links {
+  display: flex;
+  gap: var(--space-5);
+}
+
+.lp-footer-links a {
+  font-size: var(--type-body-size);
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.lp-footer-links a:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.lp-footer-copy {
+  margin: 0;
+  font-size: var(--type-footnote-size);
+  color: var(--text-tertiary);
+}
+
+/* LP Responsive */
+@media (max-width: 767px) {
+  .lp-hero {
+    padding: var(--space-10) 0;
+  }
+
+  .lp-hero-title {
+    font-size: 28px;
+  }
+
+  .lp-hero-desc {
+    font-size: var(--type-body-size);
+  }
+
+  .lp-hero-actions {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .lp-hero-actions .btn-primary,
+  .lp-hero-actions .btn-secondary {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .lp-section {
+    padding: var(--space-10) 0;
+  }
+
+  .lp-features {
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+
+  .lp-steps {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-6);
+  }
+
+  .lp-step {
+    max-width: 100%;
+  }
+
+  .lp-step-arrow {
+    transform: rotate(90deg);
+    margin: 0;
+  }
+
+  .lp-usecases {
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+
+  .lp-footer-inner {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+/* =============================================
    Toast Notification
    ============================================= */
 .toast-container {

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,16 +1,135 @@
 {{define "content"}}
-<section class="auth-shell">
-  <article class="card auth-card">
-    <div class="auth-brand">altpocket</div>
-    <p class="auth-eyebrow">Read-it-later for engineers</p>
-    <h1>Save it. Read it. Know it.</h1>
-    <p class="auth-tagline">Sign in with Google to start saving pages, tagging resources, and searching across your private knowledge base.</p>
-
-    <div class="auth-actions">
-      <a class="btn-primary" href="/v1/auth/google/login">Sign in with Google</a>
-      <a class="btn-secondary" href="/register">Create an account</a>
+<!-- Hero Section -->
+<section class="lp-hero">
+  <div class="lp-container">
+    <p class="lp-hero-eyebrow">Read-it-later for engineers</p>
+    <h1 class="lp-hero-title">Save it. Read it.<br>Know it.</h1>
+    <p class="lp-hero-desc">Web page saving, tagging, full-text search.<br>Your personal knowledge base, built for engineers.</p>
+    <div class="lp-hero-actions">
+      {{if .User}}
+        <a class="btn-primary" href="/ui/items">Go to Library</a>
+      {{else}}
+        <a class="btn-primary" href="/v1/auth/google/login">Sign in with Google</a>
+        <a class="btn-secondary" href="/register">Create an account</a>
+      {{end}}
     </div>
-    <p class="auth-legal">By continuing, you agree to our Terms.</p>
-  </article>
+  </div>
 </section>
+
+<!-- Features Section -->
+<section class="lp-section">
+  <div class="lp-container">
+    <h2 class="lp-section-title">Features</h2>
+    <div class="lp-features">
+      <article class="lp-feature-card">
+        <div class="lp-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
+          </svg>
+        </div>
+        <h3>One-click Save</h3>
+        <p>Save any web page instantly with Chrome extension or Quick Add. Never lose important articles again.</p>
+      </article>
+      <article class="lp-feature-card">
+        <div class="lp-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="4" y1="9" x2="20" y2="9"/><line x1="4" y1="15" x2="20" y2="15"/><line x1="10" y1="3" x2="8" y2="21"/><line x1="16" y1="3" x2="14" y2="21"/>
+          </svg>
+        </div>
+        <h3>Smart Tagging</h3>
+        <p>Organize your library with tags. Quickly categorize and filter content to find exactly what you need.</p>
+      </article>
+      <article class="lp-feature-card">
+        <div class="lp-feature-icon">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+        </div>
+        <h3>Full-text Search</h3>
+        <p>Search across all your saved pages instantly. Find that one article from months ago in seconds.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- How it works Section -->
+<section class="lp-section lp-section--alt">
+  <div class="lp-container">
+    <h2 class="lp-section-title">How it works</h2>
+    <div class="lp-steps">
+      <div class="lp-step">
+        <div class="lp-step-number">1</div>
+        <h3>Save</h3>
+        <p>Use the Chrome extension or paste a URL to save web pages to your personal library.</p>
+      </div>
+      <div class="lp-step-arrow" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>
+        </svg>
+      </div>
+      <div class="lp-step">
+        <div class="lp-step-number">2</div>
+        <h3>Organize</h3>
+        <p>Add tags and categorize your saved content. Build your own knowledge structure.</p>
+      </div>
+      <div class="lp-step-arrow" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>
+        </svg>
+      </div>
+      <div class="lp-step">
+        <div class="lp-step-number">3</div>
+        <h3>Discover</h3>
+        <p>Full-text search across all saved pages. Your knowledge is always at your fingertips.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Use cases Section -->
+<section class="lp-section">
+  <div class="lp-container">
+    <h2 class="lp-section-title">Built for engineers</h2>
+    <div class="lp-usecases">
+      <div class="lp-usecase">
+        <h3>Technical Research</h3>
+        <p>Save documentation, blog posts, and Stack Overflow answers for your current projects. Tag them by technology or project name.</p>
+      </div>
+      <div class="lp-usecase">
+        <h3>Learning & Growth</h3>
+        <p>Build a curated library of tutorials, conference talks, and best practices. Come back to them when you're ready to dive deeper.</p>
+      </div>
+      <div class="lp-usecase">
+        <h3>Team Knowledge</h3>
+        <p>Keep architecture decisions, design docs, and reference materials organized. Share your curated collection with your team.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA Section -->
+<section class="lp-section lp-cta">
+  <div class="lp-container">
+    <h2 class="lp-cta-title">Start building your knowledge base</h2>
+    <p class="lp-cta-desc">Free to use. Sign in with Google to get started.</p>
+    <div class="lp-hero-actions">
+      {{if .User}}
+        <a class="btn-primary" href="/ui/items">Go to Library</a>
+      {{else}}
+        <a class="btn-primary" href="/v1/auth/google/login">Sign in with Google</a>
+      {{end}}
+    </div>
+  </div>
+</section>
+
+<!-- Footer -->
+<footer class="lp-footer">
+  <div class="lp-container lp-footer-inner">
+    <div class="lp-footer-brand">altpocket</div>
+    <nav class="lp-footer-links">
+      <a href="https://www-ap.market-river.net/static/privacy.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+    </nav>
+    <p class="lp-footer-copy">&copy; 2026 altpocket. All rights reserved.</p>
+  </div>
+</footer>
 {{end}}


### PR DESCRIPTION
## Summary
- **Chrome拡張スライディングセッション**: 短命JWT (1h) + リフレッシュトークン (30日スライディング) 方式を実装。401時の自動リフレッシュ・リトライ、ログアウト時のサーバー側トークン失効、ワーカーでの期限切れトークン定期削除を追加
- **トップページLP化**: セッション時の自動リダイレクト (`/ui/items`) を削除し、Hero / Features / How it works / Use cases / CTA / Footer のLP構成に変更。フッターにプライバシーポリシーリンクを追加
- レスポンシブ対応済み、ダークテーマ対応済み

## Test plan
- [ ] Chrome拡張でログイン → refresh_tokenがstorageに保存されることを確認
- [ ] JWT期限切れ後にアイテム取得 → 自動リフレッシュで再取得されることを確認
- [ ] ログアウト → サーバー側でrefresh_tokenが失効されることを確認
- [ ] トップページ `/` にアクセス → LP表示（ログイン済みでもリダイレクトされない）
- [ ] LP各セクションの表示・レスポンシブ確認
- [ ] フッターのプライバシーポリシーリンクが正しく開くこと
- [ ] `node --test extension/sidepanel.test.mjs` が全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)