### PR TITLE
fix: /ui/items 検索が機能しない問題を修正

### DIFF
--- a/templates/items.html
+++ b/templates/items.html
@@ -6,12 +6,12 @@
 
 <!-- Mobile: Filter / Sort toggle buttons -->
 <div class="filter-toggle-bar" style="margin-bottom: var(--space-4);">
-  <div class="search-bar" style="flex:1">
+  <form class="search-bar" style="flex:1" method="get" action="/ui/items">
     <span class="search-icon" aria-hidden="true">
       <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="8.5" cy="8.5" r="6"/><line x1="13" y1="13" x2="18" y2="18"/></svg>
     </span>
-    <input type="text" name="q" placeholder="Search articles..." value="{{.Query}}" form="filter-form" aria-label="Search articles">
-  </div>
+    <input type="text" name="q" placeholder="Search articles..." value="{{.Query}}" aria-label="Search articles">
+  </form>
   <button type="button" class="filter-toggle-btn" data-sheet-toggle="filter-sheet">
     <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="3" y1="5" x2="17" y2="5"/><line x1="5" y1="10" x2="15" y2="10"/><line x1="7" y1="15" x2="13" y2="15"/></svg>
     Filters


### PR DESCRIPTION
## Summary
- モバイル検索バーの `<input name="q" form="filter-form">` がサイドバーフォーム内の `<input name="q">` と重複していたため、フォーム送信時に `q` パラメータが2つ送信されていた
- Go の `r.URL.Query().Get("q")` は最初の値（DOM順でモバイル検索バーの空値）を返すため、デスクトップでサイドバーから検索しても検索クエリが無視されていた
- モバイル検索バーを `filter-form` から切り離し、独立した `<form>` に変更して重複を解消

## Test plan
- [ ] デスクトップ: サイドバーの検索フィールドにキーワードを入力し Apply → 検索結果がフィルタされることを確認
- [ ] モバイル: 上部検索バーにキーワードを入力し Enter → 検索結果がフィルタされることを確認
- [ ] モバイル: 底部シートの検索フィールドから検索 → 正常動作を確認
- [ ] タグフィルタ・ソート・ページネーションが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)