### PR TITLE
fix(#40): worker 起動直後に cleanup と fetch を 1 サイクル実行

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -42,6 +42,17 @@ func main() {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
+	// Issue #40: run one full cycle immediately at startup so jobs queued
+	// just before/at boot are not stalled for ~1 minute waiting for the
+	// first ticker fire. The three-step order matches the ticker loop body
+	// below to keep behavior identical between the startup cycle and
+	// subsequent periodic cycles.
+	runStartupCycle(
+		func() { cleanupSessions(ctx, st, log) },
+		func() { cleanupRefreshTokens(ctx, st, log) },
+		func() { runOnce(ctx, st, f, log) },
+	)
+
 	for {
 		select {
 		case <-ticker.C:
@@ -53,6 +64,18 @@ func main() {
 			return
 		}
 	}
+}
+
+// runStartupCycle executes one cycle of the periodic worker steps in the
+// same order as the ticker loop body: expired session cleanup, expired
+// refresh-token cleanup, then the fetch run. Each step function is
+// expected to absorb its own errors (log-and-return) so this helper does
+// not propagate or short-circuit on failure. Kept as a small pure helper
+// so it can be exercised without a real DB or fetcher.
+func runStartupCycle(sessionFn, refreshFn, fetchFn func()) {
+	sessionFn()
+	refreshFn()
+	fetchFn()
 }
 
 func cleanupSessions(ctx context.Context, st *store.Store, log *slog.Logger) {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -18,3 +18,77 @@ func TestClassifyFetchErrorUnknown(t *testing.T) {
 		t.Fatalf("expected fetch_failed, got %q", got)
 	}
 }
+
+// TestRunStartupCycleInvokesAllOnce verifies AC 1.1 / 1.2 / 1.3:
+// the startup cycle must invoke the three step functions exactly once each.
+func TestRunStartupCycleInvokesAllOnce(t *testing.T) {
+	// Arrange
+	var sessionCalls, refreshCalls, fetchCalls int
+	sessionFn := func() { sessionCalls++ }
+	refreshFn := func() { refreshCalls++ }
+	fetchFn := func() { fetchCalls++ }
+
+	// Act
+	runStartupCycle(sessionFn, refreshFn, fetchFn)
+
+	// Assert
+	if sessionCalls != 1 {
+		t.Fatalf("session cleanup: expected 1 call, got %d", sessionCalls)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("refresh token cleanup: expected 1 call, got %d", refreshCalls)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("fetch run: expected 1 call, got %d", fetchCalls)
+	}
+}
+
+// TestRunStartupCycleOrderMatchesTickerLoop verifies AC 1.5:
+// the order must be cleanupSessions -> cleanupRefreshTokens -> runOnce,
+// which is the same order as the existing ticker loop body.
+func TestRunStartupCycleOrderMatchesTickerLoop(t *testing.T) {
+	// Arrange
+	var order []string
+	sessionFn := func() { order = append(order, "session") }
+	refreshFn := func() { order = append(order, "refresh") }
+	fetchFn := func() { order = append(order, "fetch") }
+
+	// Act
+	runStartupCycle(sessionFn, refreshFn, fetchFn)
+
+	// Assert
+	want := []string{"session", "refresh", "fetch"}
+	if len(order) != len(want) {
+		t.Fatalf("expected %d calls in order, got %d (%v)", len(want), len(order), order)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order mismatch at index %d: want %q, got %q (full=%v)", i, want[i], order[i], order)
+		}
+	}
+}
+
+// TestRunStartupCycleContinuesAfterStepReturn verifies AC 4.1 / 4.2 / 4.3:
+// each step must run regardless of what the previous step did internally.
+// The three step functions own their own error handling (logging + early
+// return) and never panic; runStartupCycle must not short-circuit between
+// them. We simulate "step internally handled an error and returned" by
+// having each fn simply return; we then assert all three still ran.
+func TestRunStartupCycleContinuesAfterStepReturn(t *testing.T) {
+	// Arrange
+	var calls []string
+	// Each fn represents a step that already absorbed an error internally
+	// (matches the real cleanupSessions/cleanupRefreshTokens/runOnce, which
+	// log-and-return on failure rather than propagating).
+	sessionFn := func() { calls = append(calls, "session") }
+	refreshFn := func() { calls = append(calls, "refresh") }
+	fetchFn := func() { calls = append(calls, "fetch") }
+
+	// Act
+	runStartupCycle(sessionFn, refreshFn, fetchFn)
+
+	// Assert: all three executed; none was skipped.
+	if len(calls) != 3 {
+		t.Fatalf("expected all 3 steps to run, got %d (%v)", len(calls), calls)
+	}
+}

--- a/docs/specs/40--worker-1/impl-notes.md
+++ b/docs/specs/40--worker-1/impl-notes.md
@@ -1,0 +1,101 @@
+# Implementation Notes — Issue #40 Worker startup immediate cycle
+
+## 実装サマリ
+
+- `cmd/worker/main.go` の `for { select { ... } }` 突入直前に、定期ループ本体と
+  同一順序（`cleanupSessions` → `cleanupRefreshTokens` → `runOnce`）で 1 サイクル
+  分の処理を 1 回実行する処理を追加した。
+- 上記 3 行のロジックは `runStartupCycle(sessionFn, refreshFn, fetchFn func())`
+  という小さな純粋関数に切り出し、`*store.Store` / `*fetcher.Fetcher` / 実 DB
+  への依存無しで単体テストできる形にした。`main` からはそれぞれ
+  `func() { cleanupSessions(ctx, st, log) }` 等のクロージャを渡している。
+- 既存の `cleanupSessions` / `cleanupRefreshTokens` / `runOnce` のシグネチャ・
+  内部ロジック・ログキー・エラーハンドリング方針（log-and-return、panic させ
+  ない）は一切変更していない。要件 4.x（エラー耐性）と NFR 1.1（ログ仕様）は
+  これら既存関数の挙動の再利用で満たしている。
+- `signal.Notify` は startup cycle 実行前に登録済みのため、1 サイクル中に
+  SIGINT/SIGTERM が来た場合は startup cycle 完了後の最初の `select` で
+  `<-done` ケースに入って `worker_shutdown` を出して終了する（要件 5.3 を満
+  たす。実行中の処理は既存と同じく `context.WithTimeout(ctx, 12*time.Second)`
+  で打ち切られる）。
+- ticker 間隔（1 分）、`fetcher.New(1_000_000, fullLimit, ContentSearchLimit)`
+  の引数、`sem` のサイズ（10）、フェッチタイムアウト（12 秒）、バッチサイズ
+  （50）、`config` ロード仕様、終了コード仕様は変更していない（NFR 2.1 / Out
+  of Scope）。
+
+## テスト方針
+
+DB / 外部依存なしで「起動直後 1 サイクルロジック」だけを検証するため、
+`runStartupCycle` を 3 つの `func()` 引数で受ける純粋関数として切り出し、
+`cmd/worker/main_test.go` に以下を追加した。
+
+| テスト名 | 観点 | 担保する AC |
+|---|---|---|
+| `TestRunStartupCycleInvokesAllOnce` | session/refresh/fetch がそれぞれ 1 回ずつ呼ばれる | Req 1.1 / 1.2 / 1.3 |
+| `TestRunStartupCycleOrderMatchesTickerLoop` | 呼び出し順が `session → refresh → fetch` で固定 | Req 1.5 |
+| `TestRunStartupCycleContinuesAfterStepReturn` | 各 step が return しても後続 step が必ず実行される（短絡しない） | Req 4.1 / 4.2 / 4.3 の前提条件（既存 step の log-and-return をブロックしない） |
+| 既存 `TestClassifyFetchErrorNoContent` / `TestClassifyFetchErrorUnknown` | 退行確認 | NFR 2.2 |
+
+Red → Green を確認済み（`runStartupCycle` 未定義状態でテストがビルドエラー
+となることを `go test` 出力で確認 → 実装後 5 件全 PASS）。
+
+## 受入基準カバレッジ
+
+| AC | 担保方法 |
+|---|---|
+| 1.1 起動直後にコンテンツ取得 1 回 | `runStartupCycle` 内の `fetchFn()` 呼び出し、`TestRunStartupCycleInvokesAllOnce` |
+| 1.2 起動直後にセッション削除 1 回 | `runStartupCycle` 内の `sessionFn()` 呼び出し、`TestRunStartupCycleInvokesAllOnce` |
+| 1.3 起動直後にリフレッシュトークン削除 1 回 | `runStartupCycle` 内の `refreshFn()` 呼び出し、`TestRunStartupCycleInvokesAllOnce` |
+| 1.4 起動直後 1 サイクルのログ仕様が定期実行と同一 | 既存 `cleanupSessions` / `cleanupRefreshTokens` / `runOnce` をそのまま呼び直すクロージャを渡しているため、ログキー・フィールドは定期実行と同一。コードリーディング担保（実 DB が必要なため単体テストでは検証していない） |
+| 1.5 起動直後 3 処理の実行順 = 定期実行順 | `runStartupCycle` の引数順と main 側ループの順序を一致させた `cleanupSessions → cleanupRefreshTokens → runOnce`。`TestRunStartupCycleOrderMatchesTickerLoop` |
+| 2.1 起動前後に投入されたアイテムが起動後最初のサイクルで拾われる | 最初の処理が `runOnce` を含むため、`ClaimItemsForFetch(ctx, 50)` が最初のサイクルでバッチ取得する。コードリーディング担保（実 DB 必要） |
+| 2.2 最初のサイクル開始までの待機が ticker 間隔（1 分）に依存しない | `runStartupCycle` は `signal.Notify` 直後・`for` ループ突入前に同期実行される。コードリーディング担保 |
+| 3.1 1 サイクル後も 1 分間隔で継続 | `for { select { case <-ticker.C: ... } }` を変更していない（diff で確認可能） |
+| 3.2 ticker 側の頻度・順序・引数を変更しない | 既存ループ本体は無変更。diff 確認 |
+| 3.3 起動直後実行と最初の ticker 発火の重複・競合時も単位ごとに完了 | 各 step は同期呼び出しで完了後に return。`runOnce` 内の goroutine は `wg.Wait()` で待つため、3 step の境界で必ず収束する。重複しても各 step の単位（DB 1 トランザクション・1 アイテム）は独立 |
+| 4.1 fetch 失敗時にプロセス継続 | 既存 `runOnce` の log-and-return（`worker_claim_failed` / `worker_fetch_failed`）を温存。`TestRunStartupCycleContinuesAfterStepReturn` で短絡しないことを担保 |
+| 4.2 セッション削除失敗時にプロセス継続 | 既存 `cleanupSessions` の log-and-return を温存。同上テスト |
+| 4.3 リフレッシュトークン削除失敗時にプロセス継続 | 既存 `cleanupRefreshTokens` の log-and-return を温存。同上テスト |
+| 4.4 panic させない | 既存 3 関数いずれも panic 経路無し。`runStartupCycle` 自身も recover 不要な単純呼び出しのみ |
+| 5.1 SIGINT で `worker_shutdown` ログ出力して終了 | `signal.Notify` を `runStartupCycle` 実行前に登録、`for { select }` 内 `<-done` 経路を変更していない |
+| 5.2 SIGTERM で同上 | 同上 |
+| 5.3 1 サイクル中のシグナル受信で不整合なく終了 | startup cycle は同期実行で `wg.Wait()` まで含む。完了後の最初の select で `<-done` を拾う。`runOnce` 内のフェッチは `context.WithTimeout(ctx, 12*time.Second)` で打ち切られる |
+| 5.4 シグナル受信から終了までの所要時間が 1 サイクル相当を超えない | startup cycle は最大でも `12s × バッチ` のオーダーで完了し、その後 `<-done` を即座に拾う。延長要素なし |
+| NFR 1.1 起動直後 1 サイクルでも既存ログを同一フィールドで出力 | 既存 3 関数を直接呼び出しているため自動的に同一 |
+| NFR 1.2 機密情報をログに出さない | 既存ログ出力に新規フィールド追加なし |
+| NFR 2.1 起動方法・環境変数・終了コード仕様を変更しない | `main` の前段（config / DB / fetcher 初期化）と `os.Exit(1)` 経路は無変更 |
+| NFR 2.2 既存テスト・lint 通過状態を維持 | `go test ./...` 全パス（下記実行結果参照） |
+
+## 実行結果
+
+- `go test ./...` → 全パッケージ ok（cmd/worker は `TestClassifyFetchErrorNoContent`、
+  `TestClassifyFetchErrorUnknown`、`TestRunStartupCycleInvokesAllOnce`、
+  `TestRunStartupCycleOrderMatchesTickerLoop`、`TestRunStartupCycleContinuesAfterStepReturn`
+  の 5 件 PASS）
+- `golangci-lint run` → このワークツリー環境に `golangci-lint` バイナリが
+  未インストールのため未実施。代替として `go vet ./...` を実行しエラー無しを
+  確認した。CI（`.github/workflows/ci.yml`）側で `golangci-lint` v2.11.4 が走る
+  ため、最終的な lint 担保はそちらで行う想定。
+- `go build ./...` → エラーなし
+
+## 確認事項（PR 本文に転記想定）
+
+1. **`runStartupCycle` の関数引数化**: 「直線的に書く」原則に対し抽象度を 1 段
+   上げる選択をしている。代案として「`main` 内に 3 行直書きしてテストを書か
+   ない」もあったが、要件 1.1〜1.5 を AC レベルで担保するために最小抽象として
+   採用した。妥当か確認願いたい。
+2. **既存 `cleanupSessions` / `cleanupRefreshTokens` / `runOnce` のシグネチャ
+   は無変更**とした。要件 4.x（エラー耐性）は既存実装の log-and-return が満た
+   していると判断している。仕様書の Out of Scope と整合。
+3. **重複・競合（要件 3.3）**: startup cycle 完了直後に ticker が 1 分後に発火
+   する設計になっており、現実装上「実行重複」は時間的に発生しない（1 ticker
+   サイクル分以上は startup cycle が走り終わっている）。要件 3.3 は安全側の
+   要件として読み、startup と ticker の直接的な重複防止ロジック（mutex 等）は
+   追加していない。仕様意図と一致しているか念のため確認。
+4. **環境ローカル lint 実行不可**: 上記のとおり `golangci-lint` がこのワーク
+   ツリー環境に存在しないため、ローカルでは `go vet` のみ実施。CI で本物の
+   `golangci-lint` が走る前提。
+
+## 派生タスク候補
+
+- なし（Issue #102 で扱う ticker 間隔短縮 / LISTEN-NOTIFY 化はそちらに集約済み）。

--- a/docs/specs/40--worker-1/requirements.md
+++ b/docs/specs/40--worker-1/requirements.md
@@ -1,0 +1,133 @@
+# Requirements Document
+
+## Introduction
+
+`cmd/worker` は `time.NewTicker(1 * time.Minute)` のみで処理サイクルを駆動しているため、
+プロセス起動から最初の tick が発火するまで約 1 分間アイドル状態となる。Worker 起動直後に
+投入された取得対象アイテムや期限切れセッション・期限切れリフレッシュトークンは、最大で
+約 1 分待たされてから初めて処理される。本要件では、Worker 起動直後に 1 サイクル分の
+処理（コンテンツ取得・期限切れセッション削除・期限切れリフレッシュトークン削除）が即時
+実行され、その後は従来どおり 1 分間隔で処理が継続するように、起動時挙動のみを修正する。
+
+ticker 間隔そのものの短縮や LISTEN/NOTIFY 化など、別軸の駆動方式変更は本 Issue では扱わ
+ない（Issue #102 を含む別 Issue で取り扱う）。
+
+参照: [Issue #40](https://github.com/hitoshiichikawa/altpocket-server/issues/40)
+
+## Requirements
+
+### Requirement 1: 起動直後の即時 1 サイクル実行
+
+**Objective:** As a Worker プロセスを運用する運用者, I want Worker 起動直後に処理サイクル
+が 1 回走ること, so that 起動直後に投入されたジョブや期限切れリソースが約 1 分間放置され
+ない
+
+#### Acceptance Criteria
+
+1. When Worker プロセスが起動し定期処理ループに入る前, the Worker shall コンテンツ取得処
+   理を 1 回実行する
+2. When Worker プロセスが起動し定期処理ループに入る前, the Worker shall 期限切れセッショ
+   ン削除処理を 1 回実行する
+3. When Worker プロセスが起動し定期処理ループに入る前, the Worker shall 期限切れリフレッ
+   シュトークン削除処理を 1 回実行する
+4. When 起動直後の 1 サイクルが完了した, the Worker shall そのサイクルで処理した結果を
+   従来の定期実行と同じログ仕様で出力する
+5. The Worker shall 起動直後の 1 サイクルにおける 3 種の処理（セッション削除・リフレッ
+   シュトークン削除・コンテンツ取得）の実行順序を、定期実行ループ内での実行順序と同一
+   にする
+
+### Requirement 2: 起動直後ジョブの遅延上限
+
+**Objective:** As Web UI / 拡張機能経由でアイテムを保存した利用者, I want 保存直後の本文
+取得が 1 分待たされないこと, so that 保存後すぐにアイテム本文を読める
+
+#### Acceptance Criteria
+
+1. When Worker 起動直前または起動と同時に取得対象アイテムが投入された, the Worker shall
+   当該アイテムを起動後の最初の 1 サイクルで取得対象として拾う
+2. The Worker shall 起動直後の最初の 1 サイクル開始までの待機時間を、定期 ticker 間隔
+   （現状 1 分）に依存させず、初期化処理完了から数秒以内に開始させる
+
+### Requirement 3: 定期サイクルの継続
+
+**Objective:** As a Worker プロセスを運用する運用者, I want 起動直後 1 サイクル後も従来
+どおり 1 分間隔で処理が回り続けること, so that 既存の運用前提（1 分粒度のクリーンアップ
+頻度）が崩れない
+
+#### Acceptance Criteria
+
+1. When 起動直後の 1 サイクルが完了した, the Worker shall その後 1 分間隔の ticker に従っ
+   てコンテンツ取得・期限切れセッション削除・期限切れリフレッシュトークン削除を継続実行
+   する
+2. The Worker shall 起動直後の即時実行 1 回分により、それ以降の ticker による定期実行頻
+   度・実行順序・引数を変更しない
+3. The Worker shall 起動直後の即時実行と最初の ticker 発火による実行とが重複・競合した場
+   合でも、各処理が定期実行と同じ単位で完了するようにする
+
+### Requirement 4: 起動直後実行のエラー耐性
+
+**Objective:** As a Worker プロセスを運用する運用者, I want 起動直後の 1 サイクルで一時
+的な障害が発生してもプロセスが継続すること, so that 一過性の DB / 外部障害で Worker が
+終了してしまわない
+
+#### Acceptance Criteria
+
+1. If 起動直後のコンテンツ取得処理が失敗した, the Worker shall プロセスを終了させずに、
+   従来の定期実行時と同じエラーログ仕様で記録した上で次の ticker サイクルに進む
+2. If 起動直後の期限切れセッション削除処理が失敗した, the Worker shall プロセスを終了
+   させずに、従来の定期実行時と同じエラーログ仕様で記録した上で次の処理ステップに進む
+3. If 起動直後の期限切れリフレッシュトークン削除処理が失敗した, the Worker shall プロセ
+   スを終了させずに、従来の定期実行時と同じエラーログ仕様で記録した上で次の処理ステップ
+   に進む
+4. If 起動直後の 1 サイクル中に panic が発生する状況がある, the Worker shall その状況を
+   発生させない（既存の定期実行と同じく panic させない方針を起動直後実行にも適用する）
+
+### Requirement 5: グレースフルシャットダウン互換性
+
+**Objective:** As a Worker プロセスを運用する運用者, I want 起動直後実行を追加しても
+SIGINT / SIGTERM による graceful shutdown が従来通り動作すること, so that デプロイ・再
+起動時の挙動が変わらない
+
+#### Acceptance Criteria
+
+1. When Worker プロセスが SIGINT を受信した, the Worker shall 既存挙動どおり shutdown ロ
+   グを出力して終了する
+2. When Worker プロセスが SIGTERM を受信した, the Worker shall 既存挙動どおり shutdown ロ
+   グを出力して終了する
+3. While 起動直後の 1 サイクル実行中に SIGINT または SIGTERM を受信した, the Worker shall
+   実行中の処理を不整合なく完了またはコンテキストキャンセルで打ち切ったうえで、shutdown
+   ログを出力して終了する
+4. The Worker shall 起動直後の 1 サイクル追加によって、シグナル受信から終了までの所要時
+   間を従来の定期実行 1 サイクル相当（タイムアウト付きフェッチを含めて数十秒オーダー）
+   を超えて延長しない
+
+## Non-Functional Requirements
+
+### NFR 1: 起動初期挙動の可観測性
+
+1. The Worker shall 起動直後の即時 1 サイクル実行についても、定期実行と区別なく既存の
+   構造化ログ（`worker_fetch_success` / `worker_fetch_failed` / `session_cleanup` /
+   `refresh_token_cleanup` 等）を同一フィールドで出力する
+2. The Worker shall 起動直後の即時 1 サイクルにおいてもトークン・Cookie・OAuth 生レスポ
+   ンス等の機密情報をログに出力しない（既存ロギング方針を維持する）
+
+### NFR 2: 後方互換
+
+1. The Worker shall 既存の `cmd/worker` バイナリの起動方法・環境変数・終了コードの仕様
+   を変更しない
+2. The Worker shall 既存テスト（`go test ./...`）と既存 Lint（`golangci-lint run`）の通過
+   状態を維持する
+
+## Out of Scope
+
+- ticker 間隔そのものの変更（1 分間隔は維持する）
+- LISTEN/NOTIFY 等のイベント駆動化（Issue #102 で別途扱う）
+- 取得対象アイテムの優先度付け・並列度（`sem` のサイズ）の変更
+- 期限切れセッション・期限切れリフレッシュトークン削除のロジック変更
+- 取得タイムアウト（12 秒）やバッチサイズ（50）など既存定数の変更
+- メトリクス追加・外部監視連携の追加
+- API サーバ（`cmd/api`）側の挙動変更
+
+## Open Questions
+
+- なし

--- a/docs/specs/40--worker-1/review-notes.md
+++ b/docs/specs/40--worker-1/review-notes.md
@@ -1,0 +1,77 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-01T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-40-impl--worker-1
+- HEAD commit: 17ab70c80fa0bca812990f25de7d2caf0a8ab67d
+- Compared to: main..HEAD
+- Feature Flag Protocol: opt-out (CLAUDE.md `## Feature Flag Protocol` 節 `採否: opt-out`)
+  → flag 観点の細目は適用しない（Req 4.2 / NFR 1.1 既定挙動）
+
+## Verified Requirements
+
+- 1.1 — `cmd/worker/main.go:53` で `runStartupCycle` が `runOnce` を 1 回呼び出し。
+  `TestRunStartupCycleInvokesAllOnce`（`cmd/worker/main_test.go`）で 1 回呼出を検証
+- 1.2 — `cmd/worker/main.go:51` で `cleanupSessions` を 1 回呼び出し。
+  `TestRunStartupCycleInvokesAllOnce` で検証
+- 1.3 — `cmd/worker/main.go:52` で `cleanupRefreshTokens` を 1 回呼び出し。
+  `TestRunStartupCycleInvokesAllOnce` で検証
+- 1.4 — 既存 `cleanupSessions` / `cleanupRefreshTokens` / `runOnce` のシグネチャ・
+  ログキー（`session_cleanup` / `refresh_token_cleanup` / `worker_fetch_success`
+  / `worker_fetch_failed` / `worker_claim_failed` / `worker_db_update_failed` /
+  `session_cleanup_failed` / `refresh_token_cleanup_failed`）はいずれも diff で
+  変更なし。startup cycle はクロージャ経由で同関数を呼ぶため自動的に同一仕様
+- 1.5 — 周期ループ本体（`cmd/worker/main.go:59-61`）と startup cycle の引数順
+  （`cmd/worker/main.go:50-54`）が共に session → refresh → fetch で一致。
+  `TestRunStartupCycleOrderMatchesTickerLoop` で順序を検証
+- 2.1 — `runOnce` 内 `ClaimItemsForFetch(ctx, 50)` が起動直後に呼ばれるため、
+  起動前後に投入されたアイテムは最初のサイクルで claim 対象になる（実装の
+  読み取りで担保。AC 検証としては DB が必要）
+- 2.2 — `runStartupCycle` は `signal.Notify` 直後・`for` ループ突入前に同期実行
+  （`cmd/worker/main.go:43-54`）。ticker 間隔に依存しない
+- 3.1 — `for { select { case <-ticker.C: ... } }` ブロック（`cmd/worker/main.go:56-66`）
+  は本 PR で無変更。1 分間隔の周期実行が継続
+- 3.2 — diff で周期ループ本体に変更なし（順序・引数・頻度すべて温存）
+- 3.3 — 各 step は同期呼出で完了し、`runOnce` 内 goroutine も `wg.Wait()` で
+  収束。startup と最初の ticker 発火（約 1 分後）の時間差から実行重複は実質
+  発生しない
+- 4.1 — `runOnce` の log-and-return（`worker_claim_failed` / `worker_fetch_failed`）
+  を温存。`runStartupCycle` は短絡しない（`TestRunStartupCycleContinuesAfterStepReturn`
+  で検証）
+- 4.2 — `cleanupSessions` の log-and-return（`session_cleanup_failed`）温存。同上テスト
+- 4.3 — `cleanupRefreshTokens` の log-and-return（`refresh_token_cleanup_failed`）温存。同上テスト
+- 4.4 — 既存 3 関数いずれも panic 経路無し。`runStartupCycle` も recover 不要な
+  単純呼出のみ
+- 5.1 — `signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)`（`cmd/worker/main.go:43`）
+  は startup cycle 実行前に登録済み。`<-done` 経路で `worker_shutdown` ログ出力（`main.go:63`）
+- 5.2 — 同上（SIGTERM）
+- 5.3 — `signal.Notify` は startup 前に登録済みのためシグナル受信は失われない。
+  startup cycle 完了後の最初の `select` で `<-done` を拾い `worker_shutdown` 出力。
+  fetch 中は既存の `context.WithTimeout(ctx, 12*time.Second)` で打ち切られる
+- 5.4 — startup cycle は最大でも 12 秒 × 並列度（`sem` サイズ 10）の範囲で完了
+  し、その後即座に `<-done` を読む。延長要素なし
+- NFR 1.1 — 既存 3 関数を直接呼ぶため、ログキー・フィールドは定期実行と同一
+- NFR 1.2 — 新規ログフィールド追加なし。トークン・Cookie・OAuth 生レスポンスは
+  既存どおりログに出力されない
+- NFR 2.1 — `main` 前段の config / DB / fetcher 初期化、`os.Exit(1)` 経路、環境
+  変数仕様すべて無変更
+- NFR 2.2 — `go test ./cmd/worker/...` 実行で 5 件全 PASS（reviewer 自身が再実行確認）。
+  `golangci-lint` は CI 側で担保
+
+## Findings
+
+なし
+
+## Summary
+
+要件 1.1〜5.4 / NFR 1.1〜2.2 のすべてに対し、実装またはテスト（または妥当な
+コードリーディング担保）が確認できた。3 カテゴリ（AC 未カバー / missing test /
+boundary 逸脱）のいずれにも該当しない。既存関数のシグネチャ・ログ仕様・既定値
+（ticker 間隔・並列度・タイムアウト・バッチサイズ）は全て温存されており、Out
+of Scope への侵入も無し。`runStartupCycle` 抽出により純粋関数として AC 1.1/1.2/1.3/1.5
+を単体テストで担保している点も妥当。reviewer 環境で `go test ./cmd/worker/...`
+を再実行し全 5 件 PASS を確認した。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

Worker プロセスは `time.NewTicker(1 * time.Minute)` のみで処理サイクルを駆動していたため、
起動から最初の tick 発火まで約 1 分間アイドル状態となっていた。本 PR では、定期ループ突入前に
`cleanupSessions` → `cleanupRefreshTokens` → `runOnce` の 3 ステップを 1 サイクル分同期実行する
`runStartupCycle` を追加し、起動直後の無動作期間を解消する。ticker 間隔（1 分）・並列度（10）・
タイムアウト（12 秒）・バッチサイズ（50）・ログキーはすべて温存。

## 対応 Issue

Closes #40

## 関連 PR

なし（Architect 不要 Issue のため設計 PR は作成していない）

## 実装内容

- (Req 1.1 / 1.2 / 1.3 / 1.5) `runStartupCycle(sessionFn, refreshFn, fetchFn func())` を追加し、`main` のシグナル登録直後・`for` ループ突入前に 1 回呼び出す
- (Req 4.x) 各ステップは既存の log-and-return 方針を温存し、どのステップが失敗しても後続ステップを実行する（短絡しない）
- (Req 3.x) 既存 `for { select { case <-ticker.C: ... } }` ブロックは無変更。ticker 間隔・順序・引数を維持
- (Req 5.x) `signal.Notify` は `runStartupCycle` 実行前に登録済みのため、SIGINT/SIGTERM 受信は失われない
- (NFR 2.2) `cmd/worker/main_test.go` に `runStartupCycle` の単体テストを 3 件追加

## 受入基準チェック

- [x] Req 1.1: 起動直後にコンテンツ取得を 1 回実行 ← `TestRunStartupCycleInvokesAllOnce`
- [x] Req 1.2: 起動直後にセッション削除を 1 回実行 ← `TestRunStartupCycleInvokesAllOnce`
- [x] Req 1.3: 起動直後にリフレッシュトークン削除を 1 回実行 ← `TestRunStartupCycleInvokesAllOnce`
- [x] Req 1.5: 起動直後の 3 処理の実行順が定期実行と同一（session → refresh → fetch） ← `TestRunStartupCycleOrderMatchesTickerLoop`
- [x] Req 4.1 / 4.2 / 4.3: 各ステップ失敗時もプロセス継続（短絡しない） ← `TestRunStartupCycleContinuesAfterStepReturn`
- [x] NFR 2.2: 既存テスト（`TestClassifyFetchErrorNoContent` / `TestClassifyFetchErrorUnknown`）が引き続き通過

## テスト結果

```
ok  	altpocket/cmd/worker	(cached)
--- PASS: TestClassifyFetchErrorNoContent (0.00s)
--- PASS: TestClassifyFetchErrorUnknown (0.00s)
--- PASS: TestRunStartupCycleInvokesAllOnce (0.00s)
--- PASS: TestRunStartupCycleOrderMatchesTickerLoop (0.00s)
--- PASS: TestRunStartupCycleContinuesAfterStepReturn (0.00s)
PASS (5 件全 PASS)
go test ./... → 全パッケージ ok
go build ./... → エラーなし
```

## 実装上の判断

- `runStartupCycle` を 3 つの `func()` 引数で受ける純粋関数として切り出したのは、`*store.Store` / `*fetcher.Fetcher` / 実 DB への依存なしに AC 1.1〜1.5 を単体テストで担保するため。`main` 内 3 行直書きの代案もあったが、テスト可能性のために最小抽象として採用。
- `signal.Notify` を `runStartupCycle` より前に登録することで、startup cycle 実行中のシグナル受信が失われない（Req 5.3）。startup cycle 完了後の最初の `select` で `<-done` を拾い graceful shutdown する。
- startup と最初の ticker 発火（約 1 分後）の時間差から実行重複は実質発生しない。追加の mutex 等は不要と判断（Req 3.3）。

## 確認事項 / レビュワーへの依頼

- `runStartupCycle` の関数引数化（直線的に書く原則に対し抽象度を 1 段上げる選択）の妥当性を確認願いたい。詳細は `docs/specs/40--worker-1/impl-notes.md` の「確認事項」節を参照。
- 要件 3.3（重複・競合）に対し mutex 等を追加していない判断の妥当性を確認願いたい（実行重複が時間的に発生しない前提）。
- `golangci-lint` はこのワークツリー環境に未インストールのため `go vet ./...` のみ実施。CI での lint 結果を要確認。
- Reviewer 独立判定の詳細は `docs/specs/40--worker-1/review-notes.md` を参照（RESULT: approve）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #40 のコメントを参照してください。
