### PR TITLE
fix(deploy): make staging compose self-contained to avoid ports merge defect

### DIFF
--- a/deploy/docker-compose.staging.yml
+++ b/deploy/docker-compose.staging.yml
@@ -1,7 +1,7 @@
 services:
   db:
+    image: postgres:16
     restart: unless-stopped
-    ports: []
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -10,6 +10,9 @@ services:
       - db_data_staging:/var/lib/postgresql/data
 
   api:
+    build:
+      context: ..
+      dockerfile: deploy/api.Dockerfile
     restart: unless-stopped
     ports:
       - "${STAGING_API_BIND:-127.0.0.1}:${STAGING_API_PORT:-18080}:8080"
@@ -26,8 +29,13 @@ services:
       GOOGLE_EXT_CLIENT_ID: ${GOOGLE_EXT_CLIENT_ID}
       CONTENT_FULL_LIMIT_BYTES: ${CONTENT_FULL_LIMIT_BYTES:-1000000}
       CONTENT_SEARCH_LIMIT_BYTES: ${CONTENT_SEARCH_LIMIT_BYTES:-16384}
+    depends_on:
+      - db
 
   worker:
+    build:
+      context: ..
+      dockerfile: deploy/worker.Dockerfile
     restart: unless-stopped
     environment:
       DATABASE_URL: ${DATABASE_URL}
@@ -40,6 +48,8 @@ services:
       GOOGLE_EXT_CLIENT_ID: ${GOOGLE_EXT_CLIENT_ID}
       CONTENT_FULL_LIMIT_BYTES: ${CONTENT_FULL_LIMIT_BYTES:-1000000}
       CONTENT_SEARCH_LIMIT_BYTES: ${CONTENT_SEARCH_LIMIT_BYTES:-16384}
+    depends_on:
+      - db
 
 volumes:
   db_data_staging:


### PR DESCRIPTION
## Summary

`deploy/docker-compose.staging.yml` を root の `docker-compose.yml` を重ねて使う前提から **self-contained** に変更し、Docker Compose v5 の `ports` リスト merge 仕様による defect を回避します。

## 問題

Docker Compose v5 では override 時の `ports` リストの扱いが「置換」ではなく **「追記」** に変わっています（[Compose merge spec](https://docs.docker.com/reference/compose-file/merge/)）。これにより、PR #128 で導入した overlay 方式 (`-f docker-compose.yml -f deploy/docker-compose.staging.yml`) で staging を起動すると、merged config に以下の問題が発生:

| サービス | 期待 | 実際 |
|---|---|---|
| `db` | 外部公開なし（staging override で `ports: []`）| `5432:5432` が残り **DB が外部公開される**（セキュリティ defect） |
| `api` | `${STAGING_API_BIND}:18080:8080` のみ | root の `8080:8080`（全 IF）と staging の `192.168.1.x:18080:8080` の **両方** で listen |

実機検証ログ:
```
$ docker compose --env-file deploy/.env.staging \
    -f docker-compose.yml -f deploy/docker-compose.staging.yml config | grep -A3 "ports:"
  api:
    ports:
      - target: 8080
        published: "8080"        # ← root から残留
      - host_ip: 192.168.1.117
        target: 8080
        published: "18080"
  db:
    ports:
      - target: 5432
        published: "5432"        # ← `ports: []` で消えていない
```

## 修正

staging compose を self-contained にして root yml と重ねない構成に変更:

- `db` に `image: postgres:16` を明示
- `api` / `worker` に `build:` ディレクティブを明示（context は repo root）
- `depends_on` で db への順序を明示

これで `docker compose --env-file deploy/.env.staging -f deploy/docker-compose.staging.yml` 単独で完結し、ports merge の defect を回避します。

## 検証（実機 staging サーバ）

修正版 yml で起動した結果:

```
NAME              IMAGE           PORTS
deploy-api-1      deploy-api      192.168.1.117:18080->8080/tcp
deploy-db-1       postgres:16     5432/tcp                          ← 内部のみ
deploy-worker-1   deploy-worker
```

`curl http://192.168.1.117:18080/healthz` → `200 OK / ok` を確認済。

## Out of scope（別 PR で対応）

`deploy/docker-compose.production.yml` も同じ overlay 方式で書かれており、同じ defect を抱えています。production は本番運用への影響を考慮して **本 PR では触りません**。別 PR で:

- production yml も self-contained 化
- `docs/production-docker-deploy.md` / `docs/smoke-test.md` の起動コマンドを更新（`-f docker-compose.yml -f deploy/docker-compose.production.yml` → `-f deploy/docker-compose.production.yml`）

を扱う想定。それまでは production yml の運用は変えず、現状のまま動かして問題ありません（production は外部に Caddy が立っている前提なので、5432 露出は production-docker-deploy.md の DB 公開警告通り、ホスト OS 側のファイアウォールで遮断されている前提）。

## Test plan

- [x] staging サーバ (このマシン) で実機起動確認: `docker compose --env-file deploy/.env.staging -f deploy/docker-compose.staging.yml ps` で `api` のみ `192.168.1.117:18080->8080/tcp`、`db` は内部のみ
- [x] `curl http://192.168.1.117:18080/healthz` → 200
- [ ] CI: `test` / `docker` ジョブが green
- [ ] レビュー後 `develop` へ merge → staging サーバで `git pull` のみで継続動作（既存ボリューム `db_data_staging` 再利用）

## 確認事項

- 起動コマンドが PR #128 当時の `-f docker-compose.yml -f deploy/docker-compose.staging.yml` から `-f deploy/docker-compose.staging.yml` に **変わります**。`docs/staging-docker-deploy.md` のような手順書はまだ無いので影響なし。
- production 側の同種 defect への対応は別 Issue / PR を立てるか、本 PR にまとめるか、判断ください。