### PR TITLE
feat(#85): /readyz エンドポイント追加によるヘルスチェックの liveness/readiness 分離

### DIFF
--- a/docs/specs/85--db/impl-notes.md
+++ b/docs/specs/85--db/impl-notes.md
@@ -36,8 +36,10 @@
 の漏えい禁止) のリスクが上がるため、
 
 - **レスポンス**: 固定文字列 `"unavailable"` のみ。reason / err は含めない。
-- **ログ (WARN)**: `event=health.ready.unavailable, request_id=..., reason=...,
-  error=<driver msg>` を構造化出力。
+- **ログ (WARN)**: `event=health.ready.unavailable, request_id=..., reason=...`
+  のみを構造化出力。driver 由来のエラー文字列 (`err.Error()`) は DSN 断片・
+  ホスト名・SQL 文を含み得るため、NFR 2.1 / 2.2 を満たすために**ログにも出さない**
+  (実装は `internal/server/health.go:117`〜`120` を参照)。
 
 の分離を採用。これにより前段ロードバランサは 503 を機械判定でき、運用者は
 ログから失敗原因を確認できる。
@@ -113,7 +115,7 @@
 | NFR 1.1 | /healthz は無条件で `WriteHeader+Write([]byte("ok"))` のみ。DB ping せず。50ms 未満は自明 |
 | NFR 1.2 | DB ping のタイムアウト 2 秒 (`readyDBPingTimeout`)、正常時はラウンドトリップ 1 回 |
 | NFR 1.3 | /readyz の処理は単一 goroutine 内で `context.WithTimeout` を使い、他ハンドラに影響しない |
-| NFR 2.1 | レスポンス body は固定文字列、ログには認証情報を含めない (request_id/reason/err.Error のみ) |
+| NFR 2.1 | レスポンス body は固定文字列、ログには認証情報・driver エラー文字列を含めない (`request_id` / `reason` のみ) |
 | NFR 2.2 | `TestHandleReadyResponseBodyContainsNoSecrets` |
 | NFR 3.1 | /healthz の挙動は不変なので production-docker-deploy ドキュメントは変更不要 |
 | NFR 3.2 | /healthz の応答は不変なので scripts/test-api.sh / scripts/test-api.ps1 の期待値は変更不要 |

--- a/docs/specs/85--db/impl-notes.md
+++ b/docs/specs/85--db/impl-notes.md
@@ -1,0 +1,129 @@
+# Implementation Notes — Issue #85: ヘルスチェックで DB 接続を確認する
+
+## 実装サマリ
+
+- `internal/server/health.go` (新規) — `/healthz` (liveness) と `/readyz`
+  (readiness) のハンドラ。`pinger` インターフェースを切り出し、DB ping を
+  2 秒タイムアウトで実施。失敗 / タイムアウト時は `503 unavailable` を返し、
+  構造化 WARN ログを出す。
+- `internal/server/server.go` — `Routes()` に `/readyz` ルートを追加
+  (line 126)。`handleHealth` を `health.go` へ移設し、`Server` 構造体に
+  テスト差し替え用の `readyPingerFn func(context.Context) error` を追加。
+- `internal/server/health_test.go` (新規) — `/healthz` の DB 非依存性、
+  `/readyz` の成功 / 失敗 / タイムアウト / pinger 未設定 / 機密漏えい防止を
+  カバーする単体テスト。
+
+## 設計上の判断
+
+### `pinger` インターフェース導入
+
+要件には書かれていないが、`/readyz` の失敗系・タイムアウト系を実 DB なしで
+検証可能にするため、`pinger interface { Ping(ctx context.Context) error }`
+という最小の局所インターフェースを `health.go` 内に定義し、`Server` に
+`readyPingerFn` (関数フィールド) を追加した。
+
+- 本番は `s.store.DB` (`*pgxpool.Pool`) がそのまま `pinger` を満たすため、
+  既存呼び出し経路の挙動・パフォーマンス・所有関係は一切変えない。
+- テストは `readyPingerFn` を設定するだけで成功 / 失敗 / 永久ブロック
+  (タイムアウト試験) のいずれもインメモリで再現できる。
+- インターフェースは `health.go` の package private にしているため、外部
+  パッケージから依存される心配がなく、将来の差し替え自由度を保つ。
+
+### `/readyz` 失敗時のログ vs レスポンスの分離
+
+要件 2.6 は「レスポンス body **または**ログのいずれかに失敗事実が残ること」
+を求めている。両方に出すと NFR 2.2 (内部スタックトレース・SQL 文・ホスト名等
+の漏えい禁止) のリスクが上がるため、
+
+- **レスポンス**: 固定文字列 `"unavailable"` のみ。reason / err は含めない。
+- **ログ (WARN)**: `event=health.ready.unavailable, request_id=..., reason=...,
+  error=<driver msg>` を構造化出力。
+
+の分離を採用。これにより前段ロードバランサは 503 を機械判定でき、運用者は
+ログから失敗原因を確認できる。
+
+### pinger 未設定時の挙動 (Requirement 2.3 / 4.4)
+
+`s.store` または `s.store.DB` が nil の場合 (たとえばテスト server や、
+将来の構成変更で DB を later-bind するケース)、`/readyz` は panic せず
+503 を返す。理由:
+
+- 要件 2 系は「DB ping できない状態 = readiness NG」を表現すべきと読める。
+- ハンドラ層での panic は CLAUDE.md 禁止事項。
+- 503 を返すことで前段ロードバランサがインスタンスを切り離せる。
+
+### 既存 `handleHealth` の挙動温存
+
+`/healthz` のレスポンス (HTTP 200 + body `"ok"`、Content-Type 未指定 = Go
+標準の `text/plain; charset=utf-8` 自動付与) は本要件導入前と完全に同一。
+スモークテスト (`scripts/test-api.sh`)・本番デプロイドキュメント
+(`docs/production-docker-deploy*.md`)・`docs/local-docker-deploy.md` の
+記述は変更不要。
+
+## 検証結果
+
+| コマンド | 結果 |
+|---|---|
+| `go test ./...` | **pass** (全パッケージ ok、altpocket/internal/server 2.010s) |
+| `go vet ./...` | **pass** (出力なし) |
+| `go build ./...` | **pass** (出力なし) |
+| `gofmt -l health.go health_test.go` | **clean** (私の追加ファイルは違反なし) |
+| `golangci-lint run` | **未実行** (環境に未インストール)。`.golangci.yml` 有効 linter は govet / errcheck / staticcheck。`go vet` は pass。errcheck は `_, _ = w.Write(...)` で抑制済み。staticcheck の影響は不明だが、コード自体は単純で明らかな違反なし。 |
+
+新規テストの内訳:
+
+| テスト | 対応 AC |
+|---|---|
+| `TestHandleHealthAlwaysReturnsOK` (3 サブテスト) | 1.1, 1.2, 1.3, 1.4, 5.4 |
+| `TestHandleReadySuccess` | 2.1, 2.2, 5.1 |
+| `TestHandleReadyFailureReturns503` (3 サブテスト) | 2.3, 5.2 |
+| `TestHandleReadyTimeoutReturns503` | 2.4, 2.5, 5.3, NFR 1.2 |
+| `TestHandleReadyPingerUnavailableReturns503` | 2.3, 4.4 |
+| `TestHandleReadyResponseBodyContainsNoSecrets` | 2.7, NFR 2.2 |
+
+既存テスト regression なし (`extension_contract_test.go` 含む全 pass)。
+
+### Requirement 別 トレーサビリティ
+
+| Req ID | カバー方法 |
+|---|---|
+| 1.1 | `TestHandleHealthAlwaysReturnsOK/pinger_would_succeed` |
+| 1.2 | `TestHandleHealthAlwaysReturnsOK` (全 3 ケースで `pingCalls=0` を検証) |
+| 1.3 | `TestHandleHealthAlwaysReturnsOK/pinger_would_fail_if_invoked` |
+| 1.4 | `TestHandleHealthAlwaysReturnsOK` (body=="ok", status==200 を検証。Content-Type は変更なし) |
+| 2.1 | `TestHandleReadySuccess` (`pingCalls==1` を検証) |
+| 2.2 | `TestHandleReadySuccess` (200 + "ok") |
+| 2.3 | `TestHandleReadyFailureReturns503` + `TestHandleReadyPingerUnavailableReturns503` (503) |
+| 2.4 | `TestHandleReadyTimeoutReturns503` (503) |
+| 2.5 | `TestHandleReadyTimeoutReturns503` (elapsed < 4s を検証、定数 `readyDBPingTimeout=2*time.Second`) |
+| 2.6 | `health.go:logReadyFailure` で構造化 WARN を emit (テストはログ出力検証なし。ログ I/O は io.Discard でスモーク。実装目視確認) |
+| 2.7 | `TestHandleReadyResponseBodyContainsNoSecrets` |
+| 3.1 | server.go ルート登録は `r.Get("/healthz", ...)` 直下 (auth middleware 経由しない) |
+| 3.2 | server.go ルート登録は `r.Get("/readyz", ...)` 直下 (auth middleware 経由しない) |
+| 3.3 | ハンドラ実装は session/JWT/API Key を一切読まない (実装目視) |
+| 4.1 | 既存ルートは `git diff` で path/method 不変。`go test ./...` 全 pass |
+| 4.2 | `/readyz` は既存ルートと衝突しない (新規 path) |
+| 4.3 | `r.Get(...)` で両エンドポイント登録 |
+| 4.4 | `go test ./...` 全 pass |
+| 4.5 | `scripts/test-api.sh` は line 163-165 で `GET /healthz` が 200 + "ok" を期待。私の変更で /healthz の応答は不変なのでスクリプトは継続成功する (手動実行は本ステージ対象外) |
+| 5.1 | `TestHandleReadySuccess` |
+| 5.2 | `TestHandleReadyFailureReturns503` |
+| 5.3 | `TestHandleReadyTimeoutReturns503` |
+| 5.4 | `TestHandleHealthAlwaysReturnsOK` |
+| NFR 1.1 | /healthz は無条件で `WriteHeader+Write([]byte("ok"))` のみ。DB ping せず。50ms 未満は自明 |
+| NFR 1.2 | DB ping のタイムアウト 2 秒 (`readyDBPingTimeout`)、正常時はラウンドトリップ 1 回 |
+| NFR 1.3 | /readyz の処理は単一 goroutine 内で `context.WithTimeout` を使い、他ハンドラに影響しない |
+| NFR 2.1 | レスポンス body は固定文字列、ログには認証情報を含めない (request_id/reason/err.Error のみ) |
+| NFR 2.2 | `TestHandleReadyResponseBodyContainsNoSecrets` |
+| NFR 3.1 | /healthz の挙動は不変なので production-docker-deploy ドキュメントは変更不要 |
+| NFR 3.2 | /healthz の応答は不変なので scripts/test-api.sh / scripts/test-api.ps1 の期待値は変更不要 |
+
+## 確認事項
+
+なし。要件は明確で、設計・実装上の解釈で迷う点はなかった。
+
+`golangci-lint` がローカル環境に未インストールだったため、CI 通過は GitHub
+Actions 側に委ねる。`go vet` 通過と `.golangci.yml` の enabled linter
+(govet / errcheck / staticcheck) を踏まえると問題ない見通し。
+
+STATUS: complete

--- a/docs/specs/85--db/requirements.md
+++ b/docs/specs/85--db/requirements.md
@@ -1,0 +1,145 @@
+# Requirements Document
+
+## Introduction
+
+altpocket API の `/healthz` は現在、DB 接続状態に関係なく常に HTTP 200 と body `"ok"` を
+返している。このため DB がダウンしていてもロードバランサや orchestrator から見れば
+インスタンスは健全と判定され、トラフィックが流入し続けて利用者にエラーが返る状態が
+継続する。本要件では Kubernetes 等で慣習化された liveness / readiness の分離方針
+（Issue #85 Triage で Option B として確定）を採用し、`/healthz` を軽量な liveness として
+温存しつつ、新規エンドポイント `/readyz` で DB 接続性を検査して 503 を返せるようにする。
+既存の `/healthz` 利用箇所（スモークテスト・本番デプロイドキュメント）の挙動を一切
+変更しないことが本要件の前提である。
+
+参照: [Issue #85](https://github.com/hitoshiichikawa/altpocket-server/issues/85)
+
+## Requirements
+
+### Requirement 1: Liveness エンドポイント `/healthz` の後方互換維持
+
+**Objective:** As altpocket をセルフホストで運用する管理者, I want `/healthz` がプロセス
+稼働の有無のみを示す軽量な liveness 応答を返し続けること, so that 既存のデプロイ
+ドキュメント・スモークテスト・前段のロードバランサ設定を一切変更せずに済む
+
+#### Acceptance Criteria
+
+1. When API プロセスが起動して HTTP リクエストを処理可能な状態にある, the API shall
+   `GET /healthz` に対して HTTP 200 と body `"ok"` を返す
+2. When `GET /healthz` を処理する, the API shall DB への接続確認（DB ping）を行わない
+3. When DB がダウンしている状態で `GET /healthz` を受信した, the API shall それでも
+   HTTP 200 と body `"ok"` を返す
+4. The API shall `/healthz` のレスポンスステータス・body 文字列・Content-Type 既定値を
+   本要件導入前と同一に保つ
+
+### Requirement 2: Readiness エンドポイント `/readyz` の新設と DB 接続確認
+
+**Objective:** As altpocket をセルフホストで運用する管理者, I want `/readyz` が DB 接続性を
+含む「実際にリクエストを処理できる状態か」を返すこと, so that DB ダウン時に前段の
+ロードバランサ／orchestrator がトラフィックを切り離せる
+
+#### Acceptance Criteria
+
+1. When `GET /readyz` を受信した, the API shall リクエスト処理の一部として DB への ping を
+   1 回実施する
+2. When DB ping が成功した, the API shall HTTP 200 と body `"ok"` を返す
+3. If DB ping が失敗した（接続不可・認証拒否・DB 側エラー応答等を含む）, the API shall
+   HTTP 503 を返す
+4. If DB ping がタイムアウトした, the API shall HTTP 503 を返す
+5. The API shall `/readyz` の DB ping に 2 秒のタイムアウトを設定する
+6. When DB ping が 503 で失敗した, the API shall レスポンス body または構造化ログのいずれかに
+   失敗事実が運用者から識別できる情報を残す
+7. The API shall `/readyz` のレスポンスに DB 接続文字列・パスワード・内部スタックトレースを
+   含めない
+
+### Requirement 3: 認証・公開性
+
+**Objective:** As altpocket をセルフホストで運用する管理者, I want `/healthz` と `/readyz` が
+認証なしで叩けること, so that 前段のロードバランサや orchestrator のヘルスプローブが
+追加の認証情報なしに動作する
+
+#### Acceptance Criteria
+
+1. The API shall `/healthz` を認証なしで応答可能にする
+2. The API shall `/readyz` を認証なしで応答可能にする
+3. When `/healthz` または `/readyz` を処理する, the API shall セッション Cookie・JWT・API Key
+   などの認証情報をレスポンス body・ヘッダ・ログに出力しない
+
+### Requirement 4: ルーティングと既存挙動の非破壊
+
+**Objective:** As altpocket を継続開発する開発者, I want 既存のルーティング・既存テスト・
+既存ハンドラ群が本要件導入で破壊されないこと, so that 1 PR 1 Issue の原則を保ったまま
+安全に変更を取り込める
+
+#### Acceptance Criteria
+
+1. The API shall 既存ルート（`/`, `/register`, `/v1/*`, `/ui/*`, `/mcp/*`,
+   `/manifest.webmanifest`, `/sw.js`, `/static/*`）の path・method・レスポンスを本要件
+   導入前と同一に保つ
+2. When `GET /readyz` を受信した, the API shall いずれの既存ルートとも path 衝突しない
+3. The API shall `/healthz` と `/readyz` の双方を `GET` メソッドで応答可能にする
+4. When 既存の Go テストスイート（`go test ./...`）を実行する, the test suite shall 本要件
+   導入前と同一に成功する
+5. When スモークテストスクリプト（`scripts/test-api.sh`）を実行する, the script shall 本要件
+   導入前と同一に成功する
+
+### Requirement 5: 検証可能性
+
+**Objective:** As 本機能を実装・回帰テストする開発者, I want `/readyz` の正常系・異常系・
+タイムアウトが自動テストで検証できること, so that DB 障害時の挙動を CI で継続的に
+回帰検出できる
+
+#### Acceptance Criteria
+
+1. The API shall `/readyz` の DB ping 正常系（HTTP 200）を検証するテストを追加できる構造を
+   持つ
+2. The API shall `/readyz` の DB ping 失敗系（HTTP 503）を検証するテストを追加できる構造を
+   持つ
+3. The API shall `/readyz` の DB ping タイムアウト系（HTTP 503）を検証するテストを追加できる
+   構造を持つ
+4. The API shall `/healthz` が DB の状態に依存せず HTTP 200 を返すことを検証するテストを
+   追加できる構造を持つ
+
+## Non-Functional Requirements
+
+### NFR 1: 性能・可用性
+
+1. The API shall `/healthz` の応答時間を DB 状態に関わらず 50ms 未満（同一プロセス内処理の
+   時間）に保つ
+2. The API shall `/readyz` の応答時間を DB 正常時に通常 100ms 未満（DB ping 1 回のラウンド
+   トリップを含む）に収め、異常時も Requirement 2 のタイムアウト（2 秒）を超えない
+3. The API shall `/readyz` の DB ping 失敗・タイムアウトによって他のルートのリクエスト処理を
+   ブロックまたは遅延させない
+
+### NFR 2: セキュリティ
+
+1. The API shall `/healthz` と `/readyz` のレスポンス・ログに DB 接続文字列・パスワード・
+   セッション Cookie・トークン類を出力しない
+2. The API shall `/readyz` の 503 応答 body に内部スタックトレース・SQL 文・ホスト名等の
+   機微情報を含めない
+
+### NFR 3: 互換性
+
+1. The API shall 既存の本番デプロイドキュメント（`docs/production-docker-deploy.md`,
+   `docs/production-docker-deploy-windows.md`, `docs/local-docker-deploy.md`）に記載された
+   `/healthz` の使い方を変更不要にする
+2. The API shall 既存スモークテスト（`scripts/test-api.sh`, `scripts/test-api.ps1`）の
+   `/healthz` 期待値（HTTP 200 + body `"ok"`）を変更不要にする
+
+## Out of Scope
+
+- 外部 API（Google OAuth, Google Sheets, MCP 連携先等）の包括的なヘルスチェック
+- メトリクス／監視ダッシュボード連携（Prometheus メトリクスや外形監視サービスへの export）
+- Worker プロセス（`cmd/worker`）の readiness 表現
+- DB スキーマ／マイグレーション適用状況のチェック
+- DB レプリカ・読み取り専用ノードの個別ヘルス判定
+- 既存ヘルスチェック呼出元（前段ロードバランサ・本番デプロイドキュメント）の設定変更や
+  `/readyz` への切替案内
+- `/healthz` または `/readyz` への認証付与・rate limit 追加
+
+## Open Questions
+
+なし
+
+## 関連
+
+- Related: #85

--- a/docs/specs/85--db/review-notes.md
+++ b/docs/specs/85--db/review-notes.md
@@ -1,0 +1,89 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-85-impl--db
+- HEAD commit: 0778e9f9f614866ad260e03b2125910cf782e551
+- Compared to: develop..HEAD
+- 構成: design-less impl（`tasks.md` / `design.md` 不在のため、境界判定は対象 repo の CLAUDE.md
+  「禁止事項」「コード規約」と requirements.md に従う）
+
+## Verified Requirements
+
+- 1.1 — `internal/server/health.go:handleHealth` が `WriteHeader(200) + Write("ok")` を無条件で実行。
+  `TestHandleHealthAlwaysReturnsOK/pinger_would_succeed` で検証
+- 1.2 — handleHealth は DB ping を呼ばない。`TestHandleHealthAlwaysReturnsOK` の全 3 サブテストで
+  `pingCalls == 0` をアサート
+- 1.3 — `TestHandleHealthAlwaysReturnsOK/pinger_would_fail_if_invoked`（ping が呼ばれていれば
+  失敗するが pingCalls=0 なので呼ばれず、200 + "ok" が返る）で検証
+- 1.4 — `internal/server/server.go` の diff 上、`handleHealth` は旧実装と同一バイト列を出力
+  （`WriteHeader(200)` + `Write([]byte("ok"))`。Content-Type も明示設定しないため Go 標準の
+  自動付与挙動を維持）
+- 2.1 — `handleReady` は `p.Ping(ctx)` を 1 回だけ呼ぶ。`TestHandleReadySuccess` で
+  `pingCalls == 1` を検証
+- 2.2 — `TestHandleReadySuccess` で 200 + body "ok" を検証
+- 2.3 — `TestHandleReadyFailureReturns503`（3 サブテスト: connection refused / auth rejected /
+  generic db error）と `TestHandleReadyPingerUnavailableReturns503` で 503 を検証
+- 2.4 — `TestHandleReadyTimeoutReturns503` で fake pinger を `<-ctx.Done()` で block させ、
+  ハンドラ側 `context.WithTimeout` 経由で 503 が返ることを検証
+- 2.5 — `readyDBPingTimeout = 2 * time.Second` 定数（`health.go:14`）。
+  `TestHandleReadyTimeoutReturns503` で経過時間 < 4s を確認し、5s で test guard を発火
+- 2.6 — `health.go:logReadyFailure` が `slog.Warn("health.ready.unavailable", request_id, reason, error)`
+  を構造化ログとして emit。AC は「body または log のいずれか」なので log 経路で満たす
+- 2.7 — `TestHandleReadyResponseBodyContainsNoSecrets` で sensitive DSN fragment
+  （supersecretpw / postgres:// / db.internal / alice）が body に含まれないことを検証。
+  body は固定文字列 "unavailable" のみ
+- 3.1 — `server.go:125` で `/healthz` を root に直接登録、`/v1` 以下の auth middleware の外
+- 3.2 — `server.go:126` で `/readyz` を root に直接登録、auth middleware の外
+- 3.3 — `handleHealth` / `handleReady` 実装は session/JWT/API Key を一切読まない（diff 目視確認）。
+  ログ出力も request_id / reason / error.Error のみで認証情報を含まない
+- 4.1 — diff 確認: 既存ルート（`/`, `/register`, `/v1/*`, `/ui/*`, `/mcp/*`, `/manifest.webmanifest`,
+  `/sw.js`, `/static/*`）の path・method・ハンドラ割当は不変
+- 4.2 — `/readyz` は新規 path で既存ルートと衝突しない
+- 4.3 — `r.Get("/healthz", ...)` / `r.Get("/readyz", ...)` の双方が GET 登録
+- 4.4 — impl-notes に `go test ./...` pass 記録（altpocket/internal/server 2.010s）。新規 test も
+  既存 test helper（`newAuthTestServer`）を流用するため regression なし
+- 4.5 — `/healthz` の応答が完全に不変なため `scripts/test-api.sh` line 163-165 の期待値
+  （200 + "ok"）は変更不要
+- 5.1 — `TestHandleReadySuccess`（200 系テストの構造が成立）
+- 5.2 — `TestHandleReadyFailureReturns503`（503 系テストの構造が成立）
+- 5.3 — `TestHandleReadyTimeoutReturns503`（タイムアウト系テストの構造が成立。`pinger` 抽象により
+  実 DB なしで再現可能）
+- 5.4 — `TestHandleHealthAlwaysReturnsOK`（/healthz の DB 非依存性テストの構造が成立）
+- NFR 1.1 — `handleHealth` は無条件 200 + "ok" のみで I/O ゼロ、50ms 未満は自明
+- NFR 1.2 — `readyDBPingTimeout = 2s` で異常時上限を保証、正常時は ping 1 回のみ
+- NFR 1.3 — `context.WithTimeout(r.Context(), 2s)` が当該 goroutine 内で完結し他ハンドラを
+  ブロックしない（Go の標準 net/http が per-request goroutine 起動するため）
+- NFR 2.1 — body は固定文字列、log フィールドは request_id / reason / err.Error のみ
+- NFR 2.2 — `TestHandleReadyResponseBodyContainsNoSecrets` で defense-in-depth として検証
+- NFR 3.1 — `/healthz` の応答が不変なため `docs/production-docker-deploy*.md` /
+  `docs/local-docker-deploy.md` の記述変更不要
+- NFR 3.2 — `/healthz` の応答が不変なため `scripts/test-api.sh` / `scripts/test-api.ps1` の期待値
+  変更不要
+
+## Boundary 検証
+
+- design-less impl のため `tasks.md` の `_Boundary:_` 制約は不在。CLAUDE.md 観点で確認:
+  - HTTP ハンドラは `internal/server` 配下に集約 ✅
+  - DB 操作は `internal/store.Store.DB` (pgxpool.Pool) 経由で接続のみ取得し、`pinger` 局所 interface
+    で抽象化（package private のため外部依存なし） ✅
+  - ハンドラ層で `panic` していない（pinger 未設定でも 503 を返す） ✅
+  - `slog` JSON で構造化ログを出力、トークン・Cookie・OAuth 生レスポンスを含まない ✅
+  - extension API（`extension_contract_test.go`）に影響する変更なし ✅
+  - migrations の追加なし ✅
+  - 環境変数追加なし（タイムアウト値は定数固定） ✅
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（Req 1.1–4.5, 5.1–5.4 + NFR 1.1–3.2）について、`health.go` / `health_test.go` /
+`server.go` の差分と既存 helper を突き合わせて実装・テストいずれかでカバーされていることを
+確認した。design-less impl だが CLAUDE.md の禁止事項・コード規約に違反する点はなく、
+`go test ./...` も pass 済み。境界逸脱・AC 未カバー・missing test のいずれにも該当しない。
+
+RESULT: approve

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -54,7 +55,7 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		// No DB wired in. Treat as unavailable rather than crashing so
 		// the load balancer can still strip this instance from the
 		// rotation (Requirement 2.3).
-		s.logReadyFailure(r.Context(), "pinger_unavailable", nil)
+		s.logReadyFailure(r.Context(), "pinger_unavailable")
 		writeReadyUnavailable(w)
 		return
 	}
@@ -63,11 +64,11 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	if err := p.Ping(ctx); err != nil {
-		// We log err.Error() (driver-supplied message) on the server
-		// side only. The response body stays opaque (NFR 2.2). pgx's
-		// error strings do not contain the DSN / password, but we
-		// still avoid echoing them to clients.
-		s.logReadyFailure(r.Context(), "db_ping_failed", err)
+		reason := "db_ping_failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			reason = "db_ping_timeout"
+		}
+		s.logReadyFailure(r.Context(), reason)
 		writeReadyUnavailable(w)
 		return
 	}
@@ -103,20 +104,18 @@ func writeReadyUnavailable(w http.ResponseWriter) {
 }
 
 // logReadyFailure emits a structured WARN entry for /readyz failures.
-// It deliberately omits secrets: the request ID + a short reason code
-// is enough for operators to correlate spikes with upstream incidents
-// without leaking DSN / password / cookies / tokens
-// (Requirement 3.3, NFR 2.1).
-func (s *Server) logReadyFailure(ctx context.Context, reason string, err error) {
+// It deliberately omits the driver-supplied error string: pgx (and
+// other database drivers) can embed DSN fragments, host names, or SQL
+// text in error messages, and NFR 2.1 forbids leaking those to logs.
+// A short categorical reason code plus the request ID is enough for
+// operators to correlate spikes with upstream incidents without
+// risking secret exposure (Requirement 3.3, NFR 2.1).
+func (s *Server) logReadyFailure(ctx context.Context, reason string) {
 	if s.logger == nil {
 		return
 	}
-	attrs := []any{
+	s.logger.Warn("health.ready.unavailable",
 		slog.String("request_id", s.requestID(ctx)),
 		slog.String("reason", reason),
-	}
-	if err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
-	}
-	s.logger.Warn("health.ready.unavailable", attrs...)
+	)
 }

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"log/slog"
+)
+
+// readyDBPingTimeout is the deadline applied to the DB ping issued by
+// /readyz. The value is chosen to keep readiness probes responsive
+// (NFR 1.2) while still allowing one TCP round-trip + a small DB
+// dispatch margin. (Requirement 2.5)
+const readyDBPingTimeout = 2 * time.Second
+
+// pinger is the minimal contract /readyz needs from the persistence
+// layer. Keeping it as a small local interface lets the handler depend
+// on behavior (one call: ping with a deadline) rather than the concrete
+// *pgxpool.Pool, which makes the success / failure / timeout branches
+// covered by Requirement 2 testable without spinning up a real
+// PostgreSQL instance. The production implementation is *pgxpool.Pool
+// itself (it already exposes Ping(ctx) error).
+type pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// handleHealth is the liveness endpoint. It MUST NOT touch the
+// database: the contract documented in Requirement 1 is that /healthz
+// returns HTTP 200 + body "ok" whenever the process is able to serve
+// HTTP, regardless of DB state. Existing load balancer / smoke test
+// callers depend on this exact response shape (Requirement 1.4,
+// NFR 3.1, NFR 3.2).
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// handleReady is the readiness endpoint. It issues a single DB ping
+// bounded by readyDBPingTimeout (Requirement 2.1, 2.5) and maps the
+// outcome to:
+//   - HTTP 200 + body "ok"           on success (Requirement 2.2)
+//   - HTTP 503 + body "unavailable"  on failure or timeout
+//     (Requirement 2.3, 2.4)
+//
+// On 503 a structured WARN log entry is emitted so operators can
+// observe failure spikes (Requirement 2.6). The response body and log
+// fields are intentionally short and opaque: no DB connection string,
+// driver-level stack trace, SQL text, or host metadata is included
+// (Requirement 2.7, NFR 2.1, NFR 2.2).
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	p := s.dbPinger()
+	if p == nil {
+		// No DB wired in. Treat as unavailable rather than crashing so
+		// the load balancer can still strip this instance from the
+		// rotation (Requirement 2.3).
+		s.logReadyFailure(r.Context(), "pinger_unavailable", nil)
+		writeReadyUnavailable(w)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), readyDBPingTimeout)
+	defer cancel()
+
+	if err := p.Ping(ctx); err != nil {
+		// We log err.Error() (driver-supplied message) on the server
+		// side only. The response body stays opaque (NFR 2.2). pgx's
+		// error strings do not contain the DSN / password, but we
+		// still avoid echoing them to clients.
+		s.logReadyFailure(r.Context(), "db_ping_failed", err)
+		writeReadyUnavailable(w)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// dbPinger returns the pinger backing /readyz. Tests inject a fake
+// via Server.readyPingerFn; production code falls back to the
+// underlying *pgxpool.Pool exposed by the Store (which already has
+// Ping(ctx) error).
+func (s *Server) dbPinger() pinger {
+	if s.readyPingerFn != nil {
+		return pingerFunc(s.readyPingerFn)
+	}
+	if s.store == nil || s.store.DB == nil {
+		return nil
+	}
+	return s.store.DB
+}
+
+// pingerFunc adapts a plain function into the pinger interface so
+// tests can express the ping behavior inline without declaring a
+// dedicated struct.
+type pingerFunc func(ctx context.Context) error
+
+func (f pingerFunc) Ping(ctx context.Context) error { return f(ctx) }
+
+func writeReadyUnavailable(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte("unavailable"))
+}
+
+// logReadyFailure emits a structured WARN entry for /readyz failures.
+// It deliberately omits secrets: the request ID + a short reason code
+// is enough for operators to correlate spikes with upstream incidents
+// without leaking DSN / password / cookies / tokens
+// (Requirement 3.3, NFR 2.1).
+func (s *Server) logReadyFailure(ctx context.Context, reason string, err error) {
+	if s.logger == nil {
+		return
+	}
+	attrs := []any{
+		slog.String("request_id", s.requestID(ctx)),
+		slog.String("reason", reason),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+	}
+	s.logger.Warn("health.ready.unavailable", attrs...)
+}

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,13 +1,18 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"altpocket/internal/config"
+	"altpocket/internal/ratelimit"
 )
 
 // TestHandleHealthAlwaysReturnsOK guards the liveness contract:
@@ -244,3 +249,86 @@ func containsSubstring(haystack, needle string) bool {
 	}
 	return false
 }
+
+// TestHandleReadyLogContainsNoSecrets extends Requirement 2.7 / NFR 2.1
+// coverage to the *log* path: when the DB ping fails with an error
+// whose message contains a DSN-shaped secret (the exact failure mode
+// pgx can produce when the underlying connect attempt embeds host /
+// user / password fragments in its error string), the structured WARN
+// entry emitted for /readyz must not echo any of those fragments.
+//
+// The existing TestHandleReadyResponseBodyContainsNoSecrets only
+// guards the response body. Without this test, a regression that re-
+// adds slog.String("error", err.Error()) would silently leak secrets
+// into operator logs while still passing the body assertion.
+func TestHandleReadyLogContainsNoSecrets(t *testing.T) {
+	sensitive := "postgres://alice:supersecretpw@db.internal:5432/altpocket sslmode=disable"
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	cfg := config.Config{}
+	s := New(cfg, nil, ratelimit.New(60, 60), logger, nil)
+	s.readyPingerFn = func(ctx context.Context) error {
+		return errors.New(sensitive)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+	s.handleReady(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+
+	logged := buf.String()
+	if logged == "" {
+		t.Fatalf("expected a WARN log entry on /readyz failure, got none")
+	}
+	for _, frag := range []string{"supersecretpw", "postgres://", "db.internal", "alice"} {
+		if containsSubstring(logged, frag) {
+			t.Fatalf("structured log leaked sensitive fragment %q: %s", frag, logged)
+		}
+	}
+}
+
+// TestHandleReadyLogReasonDistinguishesTimeout asserts that when the
+// DB ping fails specifically because the 2-second deadline fired, the
+// structured log entry uses the categorical reason "db_ping_timeout"
+// instead of the generic "db_ping_failed". Operators correlating
+// /readyz failure spikes need to tell timeouts apart from connect
+// refusals without having to inspect the (now redacted) underlying
+// error string.
+func TestHandleReadyLogReasonDistinguishesTimeout(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	cfg := config.Config{}
+	s := New(cfg, nil, ratelimit.New(60, 60), logger, nil)
+	s.readyPingerFn = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		s.handleReady(rr, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("handleReady did not return within 5s")
+	}
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 on timeout, got %d", rr.Code)
+	}
+	logged := buf.String()
+	if !containsSubstring(logged, "db_ping_timeout") {
+		t.Fatalf("expected reason=db_ping_timeout in log, got: %s", logged)
+	}
+}
+

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,0 +1,246 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHandleHealthAlwaysReturnsOK guards the liveness contract:
+// /healthz must answer HTTP 200 + body "ok" regardless of whether the
+// DB is reachable, because existing load balancers, smoke tests, and
+// the production deploy docs depend on that exact response shape
+// (Requirement 1.1, 1.2, 1.3, 1.4).
+//
+// To prove that no DB ping happens during /healthz, we install a
+// pinger that records each call and assert it stays at zero after
+// the handler runs.
+func TestHandleHealthAlwaysReturnsOK(t *testing.T) {
+	cases := []struct {
+		name      string
+		pingerFn  func(ctx context.Context) error
+		expectErr bool
+	}{
+		{
+			name:     "pinger nil (no DB wired)",
+			pingerFn: nil,
+		},
+		{
+			name: "pinger would fail if invoked",
+			pingerFn: func(ctx context.Context) error {
+				return errors.New("connection refused")
+			},
+			expectErr: true,
+		},
+		{
+			name: "pinger would succeed",
+			pingerFn: func(ctx context.Context) error {
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newAuthTestServer()
+			var pingCalls atomic.Int32
+			if tc.pingerFn != nil {
+				s.readyPingerFn = func(ctx context.Context) error {
+					pingCalls.Add(1)
+					return tc.pingerFn(ctx)
+				}
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			rr := httptest.NewRecorder()
+
+			s.handleHealth(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rr.Code)
+			}
+			if rr.Body.String() != "ok" {
+				t.Fatalf("expected body \"ok\", got %q", rr.Body.String())
+			}
+			if got := pingCalls.Load(); got != 0 {
+				t.Fatalf("/healthz must not invoke DB ping, got %d calls", got)
+			}
+		})
+	}
+}
+
+// TestHandleReadySuccess covers Requirement 2.1 + 2.2: /readyz issues
+// exactly one DB ping per request and, on success, answers HTTP 200
+// + body "ok".
+func TestHandleReadySuccess(t *testing.T) {
+	s := newAuthTestServer()
+	var pingCalls atomic.Int32
+	s.readyPingerFn = func(ctx context.Context) error {
+		pingCalls.Add(1)
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	s.handleReady(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	if rr.Body.String() != "ok" {
+		t.Fatalf("expected body \"ok\", got %q", rr.Body.String())
+	}
+	if got := pingCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 DB ping, got %d", got)
+	}
+}
+
+// TestHandleReadyFailureReturns503 covers Requirement 2.3:
+// any DB ping error (connection refused, auth rejected, DB-side
+// error) must collapse to HTTP 503 + body "unavailable".
+func TestHandleReadyFailureReturns503(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:5432: connect: connection refused")},
+		{name: "auth rejected", err: errors.New("pq: password authentication failed")},
+		{name: "generic db error", err: errors.New("server closed the connection unexpectedly")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newAuthTestServer()
+			s.readyPingerFn = func(ctx context.Context) error {
+				return tc.err
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			rr := httptest.NewRecorder()
+
+			s.handleReady(rr, req)
+
+			if rr.Code != http.StatusServiceUnavailable {
+				t.Fatalf("expected 503, got %d (body=%q)", rr.Code, rr.Body.String())
+			}
+			if rr.Body.String() != "unavailable" {
+				t.Fatalf("expected body \"unavailable\", got %q", rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleReadyTimeoutReturns503 covers Requirement 2.4 + 2.5: if the
+// DB ping does not return within the 2-second budget, /readyz must
+// answer HTTP 503 + body "unavailable" without blocking the request
+// goroutine indefinitely.
+//
+// We simulate a slow DB by having the fake pinger block on the
+// context's Done channel. The handler-installed deadline must fire
+// well before our 5-second test guard.
+func TestHandleReadyTimeoutReturns503(t *testing.T) {
+	s := newAuthTestServer()
+	s.readyPingerFn = func(ctx context.Context) error {
+		// Block until the handler's WithTimeout cancels us.
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		s.handleReady(rr, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("handleReady did not return within 5s; timeout enforcement is broken")
+	}
+
+	elapsed := time.Since(start)
+	// The handler's deadline is 2s. We allow a comfortable upper
+	// bound (4s) to absorb CI scheduling jitter without making the
+	// test flaky, while still rejecting the "no timeout enforced"
+	// regression where the goroutine would block for the full 5s.
+	if elapsed > 4*time.Second {
+		t.Fatalf("handleReady took %v, expected < 4s under the 2s ping timeout", elapsed)
+	}
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 on timeout, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	if rr.Body.String() != "unavailable" {
+		t.Fatalf("expected body \"unavailable\", got %q", rr.Body.String())
+	}
+}
+
+// TestHandleReadyPingerUnavailableReturns503 covers the edge case
+// where no DB pinger is wired in (e.g. Server constructed without a
+// Store). The handler must still answer 503 rather than panicking, so
+// upstream load balancers can strip the instance from rotation
+// (Requirement 2.3, Requirement 4.4).
+func TestHandleReadyPingerUnavailableReturns503(t *testing.T) {
+	s := newAuthTestServer() // store == nil, readyPingerFn == nil
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	s.handleReady(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	if rr.Body.String() != "unavailable" {
+		t.Fatalf("expected body \"unavailable\", got %q", rr.Body.String())
+	}
+}
+
+// TestHandleReadyResponseBodyContainsNoSecrets defends Requirement
+// 2.7 / NFR 2.2: when the DB ping fails, the 503 response body must
+// stay opaque. It must not echo the driver-supplied error message,
+// because pgx error strings can contain DSN fragments / SQL text /
+// internal stack traces in some failure modes.
+func TestHandleReadyResponseBodyContainsNoSecrets(t *testing.T) {
+	sensitive := "postgres://alice:supersecretpw@db.internal:5432/altpocket sslmode=disable"
+	s := newAuthTestServer()
+	s.readyPingerFn = func(ctx context.Context) error {
+		return errors.New(sensitive)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	s.handleReady(rr, req)
+
+	body := rr.Body.String()
+	if body != "unavailable" {
+		t.Fatalf("expected body \"unavailable\", got %q", body)
+	}
+	// Belt-and-suspenders: even if the body shape changes in the
+	// future, none of the sensitive fragments must ever leak.
+	for _, frag := range []string{"supersecretpw", "postgres://", "db.internal", "alice"} {
+		if containsSubstring(body, frag) {
+			t.Fatalf("response body leaked sensitive fragment %q: %s", frag, body)
+		}
+	}
+}
+
+// containsSubstring is a small wrapper so the assertion above reads
+// naturally without pulling in strings just for this check.
+func containsSubstring(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,11 @@ type Server struct {
 	randomStringFn    func(int) (string, error)
 	oauthExchangeFn   func(context.Context, string) (*oauth2.Token, error)
 	idTokenValidateFn func(context.Context, string, string) (*idtoken.Payload, error)
+	// readyPingerFn overrides the DB ping used by /readyz. It exists
+	// for tests so success / failure / timeout branches of the
+	// readiness probe can be exercised without a live PostgreSQL.
+	// When nil, /readyz falls back to s.store.DB (*pgxpool.Pool).
+	readyPingerFn func(context.Context) error
 }
 
 var errInvalidURL = errors.New("invalid_url")
@@ -118,6 +123,7 @@ func (s *Server) Routes() http.Handler {
 	r.Get("/", s.handleHome)
 	r.Get("/register", s.handleRegister)
 	r.Get("/healthz", s.handleHealth)
+	r.Get("/readyz", s.handleReady)
 	r.Get("/manifest.webmanifest", s.handleWebManifest)
 	r.Get("/sw.js", s.handleServiceWorker)
 
@@ -182,11 +188,6 @@ func (s *Server) mcpHTTPHandler() http.Handler {
 		},
 		nil,
 	)
-}
-
-func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("ok"))
 }
 
 func (s *Server) handleWebManifest(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 概要

altpocket API の `/healthz` は現在、DB 接続状態に関わらず常に 200 を返すため、DB ダウン時にも
ロードバランサからは健全と判定されトラフィックが流入し続ける問題があった。
本 PR では Kubernetes 等で慣習化された liveness / readiness の分離方針を採用し、`/healthz` を
軽量な liveness として後方互換を保ちつつ、新規エンドポイント `/readyz` で DB 接続性を検査して
503 を返せるようにする。既存の `/healthz` 利用箇所（スモークテスト・本番デプロイドキュメント）の
挙動は一切変更しない。

## 対応 Issue

Closes #85

## 関連 PR

なし（design-less impl: Architect フェーズは経由していません）

## 実装内容

- (Req 1) `internal/server/health.go`（新規）— `handleHealth`（`/healthz` liveness）と
  `handleReady`（`/readyz` readiness）のハンドラを分離。`pinger` インターフェースにより
  DB ping を 2 秒タイムアウトで実施。失敗・タイムアウト時は 503 + 固定 body `"unavailable"` を返し、
  構造化 WARN ログ（request_id / reason / error のみ）を emit
- (Req 2) `internal/server/server.go` — `Routes()` に `/readyz` ルートを追加。`handleHealth` を
  `health.go` へ移設。テスト差し替え用の `readyPingerFn` フィールドを `Server` 構造体に追加
- (Req 3 / 4) 両エンドポイントを auth middleware の外側（root 直下）に登録し、認証なしでアクセス可能に
- (Req 5) `internal/server/health_test.go`（新規）— 正常系・失敗系・タイムアウト系・pinger 未設定・
  機密漏えい防止の各テストケースを追加

## 受入基準チェック

- [x] Req 1.1: `GET /healthz` が HTTP 200 + body `"ok"` を返す ← `TestHandleHealthAlwaysReturnsOK`
- [x] Req 1.2: `/healthz` が DB ping を行わない ← `TestHandleHealthAlwaysReturnsOK`（全 3 サブテストで `pingCalls==0` を検証）
- [x] Req 1.3: DB ダウン中でも `/healthz` が 200 を返す ← `TestHandleHealthAlwaysReturnsOK/pinger_would_fail_if_invoked`
- [x] Req 1.4: `/healthz` のレスポンス仕様が導入前と同一 ← `TestHandleHealthAlwaysReturnsOK`
- [x] Req 2.1: `/readyz` が DB ping を 1 回実施 ← `TestHandleReadySuccess`（`pingCalls==1`）
- [x] Req 2.2: DB ping 成功時に 200 + `"ok"` を返す ← `TestHandleReadySuccess`
- [x] Req 2.3: DB ping 失敗時に 503 を返す ← `TestHandleReadyFailureReturns503`（3 サブテスト）+ `TestHandleReadyPingerUnavailableReturns503`
- [x] Req 2.4: DB ping タイムアウト時に 503 を返す ← `TestHandleReadyTimeoutReturns503`
- [x] Req 2.5: DB ping タイムアウトが 2 秒 ← `readyDBPingTimeout = 2 * time.Second`（`health.go:14`）
- [x] Req 2.6: 503 失敗時に運用者が識別できる情報を残す ← `logReadyFailure`（slog.Warn）
- [x] Req 2.7: レスポンスに DB 接続文字列・パスワード等を含めない ← `TestHandleReadyResponseBodyContainsNoSecrets`
- [x] Req 3.1–3.3: 両エンドポイントが認証なしで応答、認証情報をログ出力しない ← `server.go` ルート登録位置・ハンドラ実装目視確認
- [x] Req 4.1–4.5: 既存ルートの挙動が不変、テストスイート全 pass ← `go test ./...`
- [x] Req 5.1–5.4: 全テスト種別（正常系・失敗系・タイムアウト系・/healthz DB 非依存）が検証可能な構造 ← 各対応テスト

## テスト結果

```
ok  	altpocket/internal/server	2.010s
ok  	altpocket/internal/auth	0.4s
ok  	altpocket/internal/fetcher	0.3s
ok  	altpocket/internal/store	1.8s
ok  	altpocket/internal/tag	0.05s
ok  	altpocket/internal/urlnorm	0.04s
（全パッケージ pass）

go vet ./...   → pass（出力なし）
go build ./... → pass（出力なし）
gofmt -l health.go health_test.go → clean（違反なし）
```

## 実装上の判断

- **`pinger` インターフェース導入**: `health.go` 内に package private な `pinger interface { Ping(ctx context.Context) error }` を定義し、テストで `readyPingerFn` を差し替えることで実 DB なしで
  全テストケースをインメモリで再現可能にした。本番は `s.store.DB`（`*pgxpool.Pool`）がそのまま
  `pinger` を満たすため、既存経路の挙動・パフォーマンス・所有関係は一切変えない
- **レスポンス / ログの分離**: NFR 2.2 の機微情報漏えい防止のため、503 body は固定文字列
  `"unavailable"` のみとし、原因情報は構造化 WARN ログ（request_id / reason / error のみ）に分離した
- **pinger 未設定時の挙動**: `s.store` または `s.store.DB` が nil の場合もパニックせず 503 を返す。
  「DB ping できない = readiness NG」として前段が適切にトラフィックを切り離せる設計

詳細は `docs/specs/85--db/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- `golangci-lint` はローカル環境に未インストールのため CI 側での確認を依頼（`go vet` pass 済み。
  enabled linter は govet / errcheck / staticcheck。コードは単純で明らかな違反なし）
- Reviewer 独立レビューは `docs/specs/85--db/review-notes.md` を参照（RESULT: approve）
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #85 のコメントを参照してください。

<!-- idd-claude:pr-iteration round=2 last-run=2026-06-22T23:44:13Z no-progress-streak=0 -->